### PR TITLE
fix: correct signOut usage in server components and improve panel fil…

### DIFF
--- a/src/app/(authenticated)/cases/page.tsx
+++ b/src/app/(authenticated)/cases/page.tsx
@@ -4,7 +4,6 @@ import { CaseFull } from '@/app/types/case';
 import { SearchResponse } from '@/app/types/search_response';
 import { UserRole } from '@/app/types/user';
 import { onlyAdminStatuses } from '@/app/utils/case_status';
-import { signOut } from 'next-auth/react';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import CasesTable from '../../components/cases/table';
@@ -55,7 +54,7 @@ export default async function Page({ searchParams }: CasePageParams) {
   const { sinistro, page } = await searchParams;
   const user = await getCurrentUser();
   if (!user) {
-    signOut();
+    redirect('/login');
   }
 
   const data = await getData(sinistro || '', user?.role, page || 1);

--- a/src/app/(authenticated)/contractors/page.tsx
+++ b/src/app/(authenticated)/contractors/page.tsx
@@ -1,6 +1,5 @@
 `use server`;
 import { getCurrentUser } from '@/app/libs/session';
-import { signOut } from 'next-auth/react';
 import { Suspense } from 'react';
 import ContractorsTable from '../../components/contractors/table';
 import { fetchContractors } from '../../services/contractors';
@@ -44,7 +43,7 @@ export default async function Page({ searchParams }: ContractorPageParams) {
   const { nome, page } = await searchParams;
   const session = await getCurrentUser();
   if (!session) {
-    signOut();
+    redirect('/login');
   }
 
   const data = await getData(nome || '', page || 1);

--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -1,9 +1,9 @@
-import { signOut } from 'next-auth/react';
 import Snackbar from '../components/common/snackbar';
 import SideNav from '../components/sidebar/sidenav';
 import { SnackbarProvider } from '../context/SnackbarProvider';
 import { getCurrentUser } from '../libs/session';
 import FirstLoginModal from '../components/users/first-login-modal';
+import { redirect } from 'next/navigation';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -12,8 +12,7 @@ interface LayoutProps {
 export default async function Layout({ children }: LayoutProps) {
   const user = await getCurrentUser();
   if (!user) {
-    signOut();
-    return;
+    redirect('/login');
   }
 
   return (
@@ -23,15 +22,13 @@ export default async function Layout({ children }: LayoutProps) {
           <SideNav userRole={user?.role} />
         </div>
 
-        <div className="grow p-6 md:overflow-y-auto md:p-12">
-          {children}
-        </div>
+        <div className="grow p-6 md:overflow-y-auto md:p-12">{children}</div>
 
         {/* {user.isFirstLogin && (
           <FirstLoginModal userId={user.user_id} />
         )} */}
-        
-        < Snackbar />
+
+        <Snackbar />
       </div>
     </SnackbarProvider>
   );

--- a/src/app/(authenticated)/panel/page.tsx
+++ b/src/app/(authenticated)/panel/page.tsx
@@ -8,15 +8,12 @@ import { Contractor } from '@/app/types/contractor';
 import { Partner } from '@/app/types/partner';
 import { SearchResponse } from '@/app/types/search_response';
 import { UserRole } from '@/app/types/user';
-import { signOut } from 'next-auth/react';
 import { redirect } from 'next/navigation';
-import { Suspense } from 'react';
-import { CardsSkeleton } from '../../components/dashboard/skeletons';
 import { fetchCasesFull } from '../../services/cases';
 import { roboto } from '../../ui/fonts';
 import ControlPanelSummary from '@/app/components/panel/summary';
 import ControlPanelSearch from '@/app/components/panel/search';
-import { monthsNumeric } from '@/app/types/month';
+import { months, monthsNumeric } from '@/app/types/month';
 
 interface PanelFilters {
   mes?: string;
@@ -30,34 +27,25 @@ type PanelPageParams = {
   searchParams: Promise<PanelFilters>;
 };
 
-function prepareQuery(filters?: PanelFilters): string {
+function prepareQuery(filters: PanelFilters): string {
   let query = '';
 
-  if (filters?.seguradora) {
+  if (filters.seguradora) {
     query += `contractor_id=${filters.seguradora}&`;
   }
 
-  if (filters?.tecnico) {
+  if (filters.tecnico) {
     query += `partner_id=${filters.tecnico}&`;
   }
 
-  if (filters?.estado) {
+  if (filters.estado) {
     query += `state=${filters.estado}&`;
   }
 
-  let selectedMonth = -1;
-  if (filters?.mes) {
-    if (Object.keys(monthsNumeric).find((key) => key === filters.mes)) {
-      selectedMonth = monthsNumeric[filters.mes] - 1;
-    }
-  }
+  if (filters.mes && filters.mes in monthsNumeric && filters.ano) {
+    const selectedMonth = monthsNumeric[filters.mes] - 1;
+    const searchYear = parseInt(filters.ano, 10);
 
-  let searchYear = -1;
-  if (filters?.ano) {
-    searchYear = parseInt(filters.ano, 10);
-  }
-
-  if (selectedMonth >= 0 && searchYear >= 0) {
     const initialMonthDate = new Date(searchYear, selectedMonth, 1);
     initialMonthDate.setUTCHours(0, 0, 0, 0);
 
@@ -73,6 +61,16 @@ function prepareQuery(filters?: PanelFilters): string {
   return query;
 }
 
+function applyDefaultFilters(filters: PanelFilters): PanelFilters {
+  if (Object.keys(filters).length > 0) return filters;
+
+  const now = new Date();
+  return {
+    mes: months[now.getMonth()],
+    ano: String(now.getFullYear()),
+  };
+}
+
 interface PanelResult extends SearchResponse<CaseFull> {
   contractors?: Contractor[];
   partners?: Partner[];
@@ -81,9 +79,15 @@ interface PanelResult extends SearchResponse<CaseFull> {
 async function getData(filters: PanelFilters): Promise<PanelResult> {
   const query = prepareQuery(filters);
 
-  const { success, unauthorized, data } = await fetchCasesFull(query, 1, 10000);
-  if (!success || !data) {
-    if (unauthorized) {
+  const [casesResponse, contractorsResponse, partnersResponse] =
+    await Promise.all([
+      fetchCasesFull(query, 1, 10000),
+      fetchContractors('', 1, 10000),
+      fetchPartners('', 1, 10000),
+    ]);
+
+  if (!casesResponse.success || !casesResponse.data) {
+    if (casesResponse.unauthorized) {
       redirect('/login');
     }
     return {
@@ -92,11 +96,7 @@ async function getData(filters: PanelFilters): Promise<PanelResult> {
     };
   }
 
-  const contractors = await fetchContractors('', 1, 10000);
-
-  const partners = await fetchPartners('', 1, 10000);
-
-  const sortedByDate = [...data.result].sort(
+  const sortedByDate = [...casesResponse.data.result].sort(
     (a, b) =>
       new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
   );
@@ -111,9 +111,9 @@ async function getData(filters: PanelFilters): Promise<PanelResult> {
 
   return {
     result: processedResult,
-    paging: data.paging,
-    contractors: contractors.data?.result,
-    partners: partners.data?.result,
+    paging: casesResponse.data.paging,
+    contractors: contractorsResponse.data?.result,
+    partners: partnersResponse.data?.result,
   };
 }
 
@@ -121,14 +121,14 @@ export default async function Page({ searchParams }: PanelPageParams) {
   const filters = await searchParams;
   const user = await getCurrentUser();
   if (!user) {
-    signOut();
+    redirect('/login');
   }
 
   if (user?.role === UserRole.OPERATOR) {
     redirect('/home');
   }
 
-  const data = await getData(filters);
+  const data = await getData(applyDefaultFilters(filters));
 
   return (
     <main>
@@ -137,21 +137,19 @@ export default async function Page({ searchParams }: PanelPageParams) {
       </h1>
 
       <div>
-        <Suspense fallback={<CardsSkeleton />}>
-          {data.contractors && data.partners && (
-            <ControlPanelSearch
-              contractors={data.contractors || []}
-              partners={data.partners || []}
-            />
-          )}
+        {data.contractors && data.partners && (
+          <ControlPanelSearch
+            contractors={data.contractors || []}
+            partners={data.partners || []}
+          />
+        )}
 
-          {data.result && (
-            <>
-              <ControlPanelSummary cases={data.result} />
-              <ControlPanelTable cases={data} />
-            </>
-          )}
-        </Suspense>
+        {data.result && (
+          <>
+            <ControlPanelSummary cases={data.result} />
+            <ControlPanelTable cases={data} />
+          </>
+        )}
       </div>
     </main>
   );

--- a/src/app/components/cases/batch-form-modal.tsx
+++ b/src/app/components/cases/batch-form-modal.tsx
@@ -34,7 +34,7 @@ export function CreateCaseBatchModal({
       .then((resp) => {
         if (!resp.success) {
           if (resp.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
             showSnackbar(resp.message, 'error');
             return;
           }

--- a/src/app/components/cases/create-case.tsx
+++ b/src/app/components/cases/create-case.tsx
@@ -36,7 +36,7 @@ export default function CreateCaseModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/cases/form-details/customer_info.tsx
+++ b/src/app/components/cases/form-details/customer_info.tsx
@@ -50,7 +50,7 @@ export function CustomerInfoStatusForm({
       .then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           setErrorMessage(response.message || '');
           return;

--- a/src/app/components/cases/form-details/draft_case.tsx
+++ b/src/app/components/cases/form-details/draft_case.tsx
@@ -62,7 +62,7 @@ export function DraftStatusForm({ crmCase }: DraftStatusFormProps) {
       .then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           showSnackbar(response.message, 'error');
           return;

--- a/src/app/components/cases/form-details/new_case.tsx
+++ b/src/app/components/cases/form-details/new_case.tsx
@@ -29,7 +29,7 @@ export function NewCaseStatusForm({ crmCase }: NewCaseStatusFormProps) {
       .then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           setErrorMessage(response.message || '');
           return;
@@ -49,7 +49,7 @@ export function NewCaseStatusForm({ crmCase }: NewCaseStatusFormProps) {
       .then((response) => {
         if (!response.success || !response.data) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           return;
         }

--- a/src/app/components/cases/form-details/ongoing_case.tsx
+++ b/src/app/components/cases/form-details/ongoing_case.tsx
@@ -60,7 +60,7 @@ export function OnGoingStatusForm({ crmCase }: OnGoingStatusFormProps) {
     ).then((response) => {
       if (!response.success) {
         if (response.unauthorized) {
-          signOut();
+          signOut({ callbackUrl: '/login' });
         }
         showSnackbar(response.message, 'error');
         return;
@@ -87,7 +87,7 @@ export function OnGoingStatusForm({ crmCase }: OnGoingStatusFormProps) {
       .then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           showSnackbar(response.message, 'error');
           return;

--- a/src/app/components/cases/form-details/partner_info.tsx
+++ b/src/app/components/cases/form-details/partner_info.tsx
@@ -40,7 +40,7 @@ export function PartnerInfoStatusForm({ crmCase }: PartnerInfoFormProps) {
       fetchPartners(query, 1, 10000).then((response) => {
         if (!response.success || !response.data) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           setErrorMessage(response.message || '');
           return;
@@ -73,7 +73,7 @@ export function PartnerInfoStatusForm({ crmCase }: PartnerInfoFormProps) {
       changePartner(crmCase.case_id, formData).then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           setErrorMessage(response.message || '');
           return;

--- a/src/app/components/cases/form-details/receipt.tsx
+++ b/src/app/components/cases/form-details/receipt.tsx
@@ -39,7 +39,7 @@ export function ReceiptStatusForm({ crmCase }: ReceiptStatusFormProps) {
       .then((resp) => {
         if (!resp.success) {
           if (resp.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           showSnackbar(resp.message, 'error');
           return;
@@ -82,7 +82,7 @@ export function ReceiptStatusForm({ crmCase }: ReceiptStatusFormProps) {
         ).then((resp) => {
           if (!resp.success) {
             if (resp.unauthorized) {
-              signOut();
+              signOut({ callbackUrl: '/login' });
               showSnackbar(resp.message, 'error');
               return;
             }
@@ -134,7 +134,7 @@ export function ReceiptStatusForm({ crmCase }: ReceiptStatusFormProps) {
       <form className="px-5">
         <div className="mb-2">
           <h2>Técnico</h2>
-          <div className="mt-2 mb-4 grid w-full grid-cols-3 gap-4">
+          <div className="mb-4 mt-2 grid w-full grid-cols-3 gap-4">
             {formTransactions
               ?.filter((tr) => tr.type === TransactionType.OUTGOING)
               .map((transaction) => (

--- a/src/app/components/cases/form-details/report.tsx
+++ b/src/app/components/cases/form-details/report.tsx
@@ -27,7 +27,7 @@ export function ReportStatusForm({ crmCase }: ReportStatusFormProps) {
       .then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           showSnackbar(response.message, 'error');
           return;

--- a/src/app/components/cases/form-details/reset_case.tsx
+++ b/src/app/components/cases/form-details/reset_case.tsx
@@ -1,14 +1,14 @@
-"use client";
-import { useSnackbar } from "@/app/context/SnackbarProvider";
-import { resetStatus } from "@/app/services/cases";
-import { UserRole } from "@/app/types/user";
-import { roboto } from "@/app/ui/fonts";
-import { adminRoles } from "@/app/utils/roles";
-import { signOut } from "next-auth/react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { Button } from "../../common/button";
-import Modal from "../../common/modal";
+'use client';
+import { useSnackbar } from '@/app/context/SnackbarProvider';
+import { resetStatus } from '@/app/services/cases';
+import { UserRole } from '@/app/types/user';
+import { roboto } from '@/app/ui/fonts';
+import { adminRoles } from '@/app/utils/roles';
+import { signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Button } from '../../common/button';
+import Modal from '../../common/modal';
 
 interface ResetCaseButtonProps {
   caseId: string;
@@ -28,20 +28,22 @@ export function ResetCaseButton({ caseId, userRole }: ResetCaseButtonProps) {
     setLoading(true);
 
     try {
-      await resetStatus(caseId).then(response => {
-        if (!response.success) {
-          if (response.unauthorized) {
-            signOut();
+      await resetStatus(caseId)
+        .then((response) => {
+          if (!response.success) {
+            if (response.unauthorized) {
+              signOut({ callbackUrl: '/login' });
+            }
+            showSnackbar(response.message, 'error');
+            return;
           }
-          showSnackbar(response.message, 'error');
-          return;
-        }
 
-        showSnackbar(response.message, 'success');
-        refresh();
-      }).catch((error) => {
-        showSnackbar(error, 'error');
-      });
+          showSnackbar(response.message, 'success');
+          refresh();
+        })
+        .catch((error) => {
+          showSnackbar(error, 'error');
+        });
     } finally {
       setLoading(false);
       setShowConfirmation(false);
@@ -54,24 +56,27 @@ export function ResetCaseButton({ caseId, userRole }: ResetCaseButtonProps) {
 
   return (
     <>
-      {isAdminRole && <Button
-        onClick={() => setShowConfirmation(true)}
-        color="warning"
-        disabled={loading}
-        isLoading={loading}
-        size="md"
-      >
-        Resetar caso
-      </Button>}
+      {isAdminRole && (
+        <Button
+          onClick={() => setShowConfirmation(true)}
+          color="warning"
+          disabled={loading}
+          isLoading={loading}
+          size="md"
+        >
+          Resetar caso
+        </Button>
+      )}
 
       {showConfirmation && (
         <Modal isOpen={showConfirmation} onClose={onClose}>
-          <h1 className={`${roboto.className} mt-3 mb-2 mx-5 text-xl`}>
+          <h1 className={`${roboto.className} mx-5 mb-2 mt-3 text-xl`}>
             Tem certeza que deseja resetar o caso?
           </h1>
 
-          <p className={`${roboto.className} mb-5 mx-5 text-md`}>
-            Esta ação irá remover todas as informações do caso e reiniciar o fluxo.
+          <p className={`${roboto.className} text-md mx-5 mb-5`}>
+            Esta ação irá remover todas as informações do caso e reiniciar o
+            fluxo.
           </p>
 
           <div className="flex justify-center space-x-8">
@@ -98,5 +103,5 @@ export function ResetCaseButton({ caseId, userRole }: ResetCaseButtonProps) {
         </Modal>
       )}
     </>
-  )
+  );
 }

--- a/src/app/components/cases/form-details/transactions.tsx
+++ b/src/app/components/cases/form-details/transactions.tsx
@@ -90,7 +90,7 @@ export function TransactionStatusForm({ crmCase }: TransactionStatusFormProps) {
       );
       if (!transactionResp.success) {
         if (transactionResp.unauthorized) {
-          signOut();
+          signOut({ callbackUrl: '/login' });
         }
         showSnackbar(transactionResp.message, 'error');
         return;
@@ -102,7 +102,7 @@ export function TransactionStatusForm({ crmCase }: TransactionStatusFormProps) {
       );
       if (!statusResp.success) {
         if (statusResp.unauthorized) {
-          signOut();
+          signOut({ callbackUrl: '/login' });
         }
         showSnackbar(statusResp.message, 'error');
         return;

--- a/src/app/components/cases/target-date-modal.tsx
+++ b/src/app/components/cases/target-date-modal.tsx
@@ -32,7 +32,7 @@ export default function TargetDateModal({
     update(caseId, formData).then((response) => {
       if (!response.success) {
         if (response.unauthorized) {
-          signOut();
+          signOut({ callbackUrl: '/login' });
         }
         setErrorMessage(response.message || '');
         return;

--- a/src/app/components/contractors/create-contractor.tsx
+++ b/src/app/components/contractors/create-contractor.tsx
@@ -34,7 +34,7 @@ export default function CreateContractorModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/contractors/delete-contractor.tsx
+++ b/src/app/components/contractors/delete-contractor.tsx
@@ -36,7 +36,7 @@ export function DeleteContractorModal({
       onClose();
     } else {
       if (state?.unauthorized) {
-        signOut();
+        signOut({ callbackUrl: '/login' });
       }
       showSnackbar(state?.message || '', 'error');
     }

--- a/src/app/components/contractors/edit-contractor.tsx
+++ b/src/app/components/contractors/edit-contractor.tsx
@@ -62,7 +62,7 @@ export default function EditContractorModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/customers/create-customer.tsx
+++ b/src/app/components/customers/create-customer.tsx
@@ -34,7 +34,7 @@ export default function CreateCustomerModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/customers/delete-customer.tsx
+++ b/src/app/components/customers/delete-customer.tsx
@@ -36,7 +36,7 @@ export function DeleteCustomerModal({
       onClose();
     } else {
       if (state?.unauthorized) {
-        signOut();
+        signOut({ callbackUrl: '/login' });
       }
       showSnackbar(state?.message || '', 'error');
     }

--- a/src/app/components/customers/edit-customer.tsx
+++ b/src/app/components/customers/edit-customer.tsx
@@ -57,7 +57,7 @@ export default function EditCustomerModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/panel/search.tsx
+++ b/src/app/components/panel/search.tsx
@@ -66,9 +66,14 @@ export default function ControlPanelSearch({
     setPartnerId('');
     setState('');
     setContractorId('');
-    setMonth(months[new Date().getMonth()]);
-    setAno(String(currentYear));
-    router.push(pathname);
+    const currentMonth = months[new Date().getMonth()];
+    const currentAno = String(new Date().getFullYear());
+    setMonth(currentMonth);
+    setAno(currentAno);
+    const params = new URLSearchParams();
+    params.set('mes', currentMonth);
+    params.set('ano', currentAno);
+    router.push(pathname + '?' + params.toString());
   };
 
   return (
@@ -154,7 +159,7 @@ export default function ControlPanelSearch({
               <MagnifyingGlassIcon className="h-5 w-5 text-gray-500" />
             }
             value={partnerId || undefined}
-            onChange={handlePartnerChange}
+            onSelectionChange={handlePartnerChange}
             defaultItems={partners}
           >
             {(item) => (

--- a/src/app/components/partners/create-partner.tsx
+++ b/src/app/components/partners/create-partner.tsx
@@ -33,7 +33,7 @@ export default function CreatePartnerModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/partners/delete-partner.tsx
+++ b/src/app/components/partners/delete-partner.tsx
@@ -36,7 +36,7 @@ export function DeletePartnerModal({
       onClose();
     } else {
       if (state?.unauthorized) {
-        signOut();
+        signOut({ callbackUrl: '/login' });
       }
       showSnackbar(state?.message || '', 'error');
     }

--- a/src/app/components/partners/edit-partner.tsx
+++ b/src/app/components/partners/edit-partner.tsx
@@ -57,7 +57,7 @@ export default function EditPartnerModal({
       refresh();
       onClose();
     } else if (state.unauthorized) {
-      signOut();
+      signOut({ callbackUrl: '/login' });
     }
   }, [state, showSnackbar, refresh, onClose]);
 

--- a/src/app/components/payments/confirm-payment.tsx
+++ b/src/app/components/payments/confirm-payment.tsx
@@ -54,7 +54,7 @@ export function ConfirmPaymentModal({
       .then((response) => {
         if (!response.success) {
           if (response.unauthorized) {
-            signOut();
+            signOut({ callbackUrl: '/login' });
           }
           showSnackbar(response.message, 'error');
           return;

--- a/src/app/components/payments/edit-payment.tsx
+++ b/src/app/components/payments/edit-payment.tsx
@@ -64,7 +64,7 @@ export function EditPaymentModal({
         updateTransaction(tr.transactionID, tr.value).then((resp) => {
           if (!resp.success) {
             if (resp.unauthorized) {
-              signOut();
+              signOut({ callbackUrl: '/login' });
               showSnackbar(resp.message, 'error');
               return;
             }

--- a/src/app/components/sidebar/sidenav.tsx
+++ b/src/app/components/sidebar/sidenav.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import { UserRole } from '@/app/types/user';
 import { PowerIcon } from '@heroicons/react/24/outline';
 import { signOut } from 'next-auth/react';
@@ -16,11 +16,11 @@ export default function SideNav({ userRole }: SideNavProps) {
   return (
     <div className="flex h-full flex-col px-3 py-4 md:px-2">
       <Link
-        className="mb-2 flex h-20 items-end justify-start rounded-md p-2 bg-gray-100 md:h-40"
+        className="mb-2 flex h-20 items-end justify-start rounded-md bg-gray-100 p-2 md:h-40"
         href="/home"
       >
-        <div className="relative w-full h-full">
-          <Image src={logoPic} fill alt='rd logo png image' />
+        <div className="relative h-full w-full">
+          <Image src={logoPic} fill alt="rd logo png image" />
         </div>
       </Link>
 
@@ -31,7 +31,7 @@ export default function SideNav({ userRole }: SideNavProps) {
 
         <button
           className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3"
-          onClick={() => signOut()}
+          onClick={() => signOut({ callbackUrl: '/login' })}
         >
           <PowerIcon className="w-6" />
           <div className="hidden md:block">Sair</div>

--- a/src/app/components/users/first-login-modal.tsx
+++ b/src/app/components/users/first-login-modal.tsx
@@ -49,7 +49,7 @@ export default function FirstLoginModal({ userId }: FirstLoginModalProps) {
       const resp = await updateUser(userId, updateFormData);
       if (!resp.success) {
         if (resp.unauthorized) {
-          signOut();
+          signOut({ callbackUrl: '/login' });
         }
         setErrorMessage(resp.message);
         return;


### PR DESCRIPTION
…ters

- Replace no-op signOut() from next-auth/react with redirect('/login') in all server components (layout, panel, cases, contractors pages)
- Add { callbackUrl: '/login' } to all signOut() calls in client components so users are always redirected to login after logout or 401
- Parallelize fetchCasesFull, fetchContractors and fetchPartners in panel with Promise.all
- Extract applyDefaultFilters to inject current month/year only on first load (no URL params), keeping prepareQuery as a pure query builder
- Fix handleClean in panel search to include mes/ano in URL, keeping URL in sync with displayed data
- Fix Autocomplete to use onSelectionChange instead of onChange for correct key handling

## 📝 Descrição

[Explique de forma clara e resumida o propósito deste PR. Qual problema ele resolve ou qual componente ele adiciona? Se houver um ticket/issue associado, coloque o link aqui.]

## 🖼️ Alterações Visuais (UI/UX)

[Se este PR altera a interface, adicione screenshots ou um pequeno vídeo/GIF mostrando o antes e o depois, ou como a nova tela se comporta.]

- **Desktop:** [Insira a imagem aqui, se aplicável]
- **Mobile:** [Insira a imagem aqui, se aplicável]

## 🔄 Tipo de Mudança

- [ ] 🐛 Bugfix (correção de um erro)
- [ ] ✨ Feature (nova funcionalidade)
- [ ] 💄 Estilização (mudanças de CSS/Tailwind, layout)
- [ ] ♻️ Refatoração (mudança de código que não altera comportamento)
- [ ] ⚡ Performance (melhoria de tempo de carregamento, Web Vitals)

## 📋 Checklist de Validação

_Por favor, marque os itens abaixo antes de solicitar a revisão:_

- [ ] Meu código passou sem erros no linter (`npm run lint`) e no Prettier.
- [ ] Adicionei ou atualizei os testes unitários (Jest/Testing Library) para os novos componentes.
- [ ] Todos os testes locais e no pipeline de CI estão passando (`npm run test:ci`).
- [ ] Verifiquei se o layout está responsivo (testado em telas menores).
- [ ] Validei se a build de produção não está quebrando (`npm run build`).
- [ ] O título do PR segue o padrão do projeto (Conventional Commits).
