### PR TITLE
perf: reduce Vercel Fast Origin Transfer

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,9 @@
+import bundleAnalyzer from '@next/bundle-analyzer';
+
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
+
 /** @type {import('next').NextConfig} */
 const securityHeaders = [
   { key: 'X-Content-Type-Options', value: 'nosniff' },
@@ -9,6 +15,20 @@ const securityHeaders = [
     key: 'Strict-Transport-Security',
     value: 'max-age=63072000; includeSubDomains; preload',
   },
+];
+
+// private = apenas browser, nunca CDN (seguro para rotas autenticadas)
+// stale-while-revalidate = browser serve o cache stale enquanto busca fresh em background
+const cacheMedium = [
+  { key: 'Cache-Control', value: 'private, max-age=60, stale-while-revalidate=300' },
+];
+
+const cacheLow = [
+  { key: 'Cache-Control', value: 'private, max-age=300, stale-while-revalidate=1800' },
+];
+
+const cacheDetailCase = [
+  { key: 'Cache-Control', value: 'private, max-age=30, stale-while-revalidate=60' },
 ];
 
 const nextConfig = {
@@ -32,8 +52,27 @@ const nextConfig = {
         source: '/:path*',
         headers: securityHeaders,
       },
+
+      // Páginas de média frequência (dados mudam algumas vezes por dia)
+      { source: '/cases', headers: cacheMedium },
+      { source: '/customers', headers: cacheMedium },
+      { source: '/customers/:id', headers: cacheMedium },
+      { source: '/payments', headers: cacheMedium },
+      { source: '/panel', headers: cacheMedium },
+
+      // Detalhe do case: TTL curto pois o status muda durante o fluxo de atendimento
+      { source: '/cases/:caseID', headers: cacheDetailCase },
+
+      // Páginas de baixa frequência (dados mudam raramente)
+      { source: '/partners', headers: cacheLow },
+      { source: '/partners/:id', headers: cacheLow },
+      { source: '/contractors', headers: cacheLow },
+      { source: '/contractors/:id', headers: cacheLow },
+      { source: '/users', headers: cacheLow },
+      { source: '/dashboards', headers: cacheLow },
+      { source: '/home', headers: cacheLow },
     ];
   },
 };
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "zod": "3.24.1"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.7",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@types/bcrypt": "6.0.0",
@@ -1501,6 +1502,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -8095,6 +8106,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.7.tgz",
+      "integrity": "sha512-Lh52e3gpnJQ8ZwBNsp54g/Czg1oqbx7bdZ9mEqHfI0VbtNMHCpneYNzKj6C+oW1JIeyjpmRSRGnhGOmi0SdNow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -8307,6 +8328,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@react-aria/breadcrumbs": {
       "version": "3.5.32",
@@ -14560,6 +14588,13 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -14738,6 +14773,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -16070,6 +16112,22 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -16669,6 +16727,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -18458,6 +18526,16 @@
       "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "peer": true
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -19312,6 +19390,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/openid-client": {
@@ -20707,6 +20795,21 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -21418,6 +21521,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -21934,6 +22047,66 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postclean": "npm i && npm run build",
     "dev": "next dev",
     "build": "next build",
+    "analyze": "ANALYZE=true next build --no-turbopack",
     "start": "next start",
     "lint": "eslint .",
     "prettier": "prettier --write --ignore-unknown .",
@@ -51,6 +52,7 @@
     "zod": "3.24.1"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.7",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@types/bcrypt": "6.0.0",

--- a/src/app/(authenticated)/cases/page.tsx
+++ b/src/app/(authenticated)/cases/page.tsx
@@ -1,7 +1,7 @@
 `use server`;
 import { unauthorizedRedirect } from '@/app/libs/auth-redirect';
 import { getCurrentUser } from '@/app/libs/session';
-import { CaseFull } from '@/app/types/case';
+import { CaseListItem } from '@/app/types/case-list-item';
 import { SearchResponse } from '@/app/types/search_response';
 import { UserRole } from '@/app/types/user';
 import { onlyAdminStatuses } from '@/app/utils/case_status';
@@ -21,7 +21,7 @@ async function getData(
   sinistro: string,
   userRole: UserRole | undefined,
   page: number
-): Promise<SearchResponse<CaseFull>> {
+): Promise<SearchResponse<CaseListItem>> {
   let query = '';
   if (sinistro) {
     query = `external_reference=${sinistro}`;
@@ -35,20 +35,29 @@ async function getData(
     return { result: [], paging: { limit: 10, offset: page * 10, total: 0 } };
   }
 
-  const cases = data.result;
-
-  let filteredCases = cases;
+  let filteredCases = data.result;
 
   if (userRole === UserRole.OPERATOR) {
-    filteredCases = cases.filter(
+    filteredCases = filteredCases.filter(
       (crmCase) => !onlyAdminStatuses.includes(crmCase.status)
     );
   }
 
-  return {
-    result: filteredCases,
-    paging: data.paging,
-  };
+  const listItems = filteredCases.map(
+    (c): CaseListItem => ({
+      case_id: c.case_id,
+      external_reference: c.external_reference,
+      status: c.status,
+      due_date: c.due_date,
+      customer_first_name: c.customer?.first_name,
+      customer_last_name: c.customer?.last_name,
+      customer_city: c.customer?.shipping?.city,
+      contractor_company_name: c.contractor?.company_name,
+      partner_first_name: c.partner?.first_name,
+    })
+  );
+
+  return { result: listItems, paging: data.paging };
 }
 
 export default async function Page({ searchParams }: CasePageParams) {

--- a/src/app/(authenticated)/contractors/page.tsx
+++ b/src/app/(authenticated)/contractors/page.tsx
@@ -4,8 +4,8 @@ import { getCurrentUser } from '@/app/libs/session';
 import { Suspense } from 'react';
 import ContractorsTable from '../../components/contractors/table';
 import { fetchContractors } from '../../services/contractors';
+import { ContractorListItem } from '@/app/types/contractor-list-item';
 import { SearchResponse } from '@/app/types/search_response';
-import { Contractor } from '@/app/types/contractor';
 import { redirect } from 'next/navigation';
 
 type ContractorPageParams = {
@@ -18,7 +18,7 @@ type ContractorPageParams = {
 async function getData(
   nome: string,
   page: number
-): Promise<SearchResponse<Contractor>> {
+): Promise<SearchResponse<ContractorListItem>> {
   let query = '';
   if (nome) {
     query = `company_name=${nome}`;
@@ -32,12 +32,18 @@ async function getData(
     return { result: [], paging: { limit: 10, offset: page * 10, total: 0 } };
   }
 
-  const contractors = data.result;
+  const listItems = data.result.map(
+    (c): ContractorListItem => ({
+      contractor_id: c.contractor_id,
+      company_name: c.company_name,
+      legal_name: c.legal_name,
+      document: c.document,
+      created_at: c.created_at,
+      active: c.active,
+    })
+  );
 
-  return {
-    result: contractors,
-    paging: data.paging,
-  };
+  return { result: listItems, paging: data.paging };
 }
 
 export default async function Page({ searchParams }: ContractorPageParams) {

--- a/src/app/(authenticated)/customers/page.tsx
+++ b/src/app/(authenticated)/customers/page.tsx
@@ -2,7 +2,7 @@
 import { unauthorizedRedirect } from '@/app/libs/auth-redirect';
 import { removeDocumentSymbols } from '@/app/libs/parser';
 import { getCurrentUser } from '@/app/libs/session';
-import { Customer } from '@/app/types/customer';
+import { CustomerListItem } from '@/app/types/customer-list-item';
 import { SearchResponse } from '@/app/types/search_response';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
@@ -19,7 +19,7 @@ type CustomerPageParams = {
 async function getData(
   document: string,
   page: number
-): Promise<SearchResponse<Customer>> {
+): Promise<SearchResponse<CustomerListItem>> {
   let query = '';
   if (document) {
     const parsedDocument = removeDocumentSymbols(document);
@@ -34,12 +34,19 @@ async function getData(
     return { result: [], paging: { limit: 10, offset: page * 10, total: 0 } };
   }
 
-  const customers = data.result;
+  const listItems = data.result.map(
+    (c): CustomerListItem => ({
+      customer_id: c.customer_id,
+      first_name: c.first_name,
+      last_name: c.last_name,
+      email: c.personal_contact?.email,
+      document: c.document,
+      created_at: c.created_at,
+      active: c.active,
+    })
+  );
 
-  return {
-    result: customers,
-    paging: data.paging,
-  };
+  return { result: listItems, paging: data.paging };
 }
 
 export default async function Page({ searchParams }: CustomerPageParams) {

--- a/src/app/(authenticated)/dashboards/page.tsx
+++ b/src/app/(authenticated)/dashboards/page.tsx
@@ -1,12 +1,11 @@
 'use server';
 import Achievements from '@/app/components/dashboards/achievements';
 import KpiCards from '@/app/components/dashboards/kpi-cards';
-import PerformanceChart from '@/app/components/dashboards/performance-chart';
+import PerformanceChartLazy from '@/app/components/dashboards/performance-chart-lazy';
 import PeriodFilter from '@/app/components/dashboards/period-filter';
 import Ranking from '@/app/components/dashboards/ranking';
 import Rewards from '@/app/components/dashboards/rewards';
 import {
-  ChartSkeleton,
   GenericSkeleton,
   KpiCardsSkeleton,
   RankingSkeleton,
@@ -65,9 +64,7 @@ export default async function Page() {
       </div>
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <Suspense fallback={<ChartSkeleton />}>
-          <PerformanceChart />
-        </Suspense>
+        <PerformanceChartLazy />
         <Suspense fallback={<GenericSkeleton />}>
           <Rewards />
         </Suspense>

--- a/src/app/(authenticated)/panel/page.tsx
+++ b/src/app/(authenticated)/panel/page.tsx
@@ -4,10 +4,13 @@ import { unauthorizedRedirect } from '@/app/libs/auth-redirect';
 import { getCurrentUser } from '@/app/libs/session';
 import { fetchContractors } from '@/app/services/contractors';
 import { fetchPartners } from '@/app/services/partners';
-import { CaseFull, CaseStatus } from '@/app/types/case';
-import { Contractor } from '@/app/types/contractor';
-import { Partner } from '@/app/types/partner';
-import { SearchResponse } from '@/app/types/search_response';
+import { CaseStatus } from '@/app/types/case';
+import {
+  PanelCaseItem,
+  PanelContractorOption,
+  PanelPartnerOption,
+  PanelTransactionItem,
+} from '@/app/types/panel-case-item';
 import { redirect } from 'next/navigation';
 import { adminRoles } from '@/app/utils/roles';
 import { fetchCasesFull } from '../../services/cases';
@@ -72,12 +75,14 @@ function applyDefaultFilters(filters: PanelFilters): PanelFilters {
   };
 }
 
-interface PanelResult extends SearchResponse<CaseFull> {
-  contractors?: Contractor[];
-  partners?: Partner[];
+interface PanelData {
+  result: PanelCaseItem[];
+  paging: { total: number; limit: number; offset: number };
+  contractors?: PanelContractorOption[];
+  partners?: PanelPartnerOption[];
 }
 
-async function getData(filters: PanelFilters): Promise<PanelResult> {
+async function getData(filters: PanelFilters): Promise<PanelData> {
   const query = prepareQuery(filters);
 
   const [casesResponse, contractorsResponse, partnersResponse] =
@@ -102,7 +107,7 @@ async function getData(filters: PanelFilters): Promise<PanelResult> {
       new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
   );
 
-  const groupsByDocument = new Map<string, CaseFull[]>();
+  const groupsByDocument = new Map<string, typeof sortedByDate>();
   for (const c of sortedByDate) {
     const key = c.customer?.document || c.case_id;
     if (!groupsByDocument.has(key)) groupsByDocument.set(key, []);
@@ -110,11 +115,46 @@ async function getData(filters: PanelFilters): Promise<PanelResult> {
   }
   const processedResult = [...groupsByDocument.values()].flat();
 
+  const projectedCases = processedResult.map(
+    (c): PanelCaseItem => ({
+      case_id: c.case_id,
+      created_at: c.created_at,
+      type: c.type,
+      external_reference: c.external_reference,
+      customer_document: c.customer?.document,
+      customer_first_name: c.customer?.first_name,
+      customer_last_name: c.customer?.last_name,
+      customer_city: c.customer?.shipping?.city,
+      partner_first_name: c.partner?.first_name,
+      contractor_company_name: c.contractor?.company_name,
+      transactions: c.transactions?.map(
+        (t): PanelTransactionItem => ({
+          type: t.type,
+          description: t.description,
+          value: t.value,
+        })
+      ),
+    })
+  );
+
   return {
-    result: processedResult,
+    result: projectedCases,
     paging: casesResponse.data.paging,
-    contractors: contractorsResponse.data?.result,
-    partners: partnersResponse.data?.result,
+    contractors: contractorsResponse.data?.result.map(
+      (c): PanelContractorOption => ({
+        contractor_id: c.contractor_id,
+        company_name: c.company_name,
+      })
+    ),
+    partners: partnersResponse.data?.result.map(
+      (p): PanelPartnerOption => ({
+        partner_id: p.partner_id,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        city: p.shipping.city,
+        state: p.shipping.state,
+      })
+    ),
   };
 }
 
@@ -148,7 +188,9 @@ export default async function Page({ searchParams }: PanelPageParams) {
         {data.result && (
           <>
             <ControlPanelSummary cases={data.result} />
-            <ControlPanelTable cases={data} />
+            <ControlPanelTable
+              cases={{ result: data.result, paging: data.paging }}
+            />
           </>
         )}
       </div>

--- a/src/app/(authenticated)/partners/page.tsx
+++ b/src/app/(authenticated)/partners/page.tsx
@@ -4,7 +4,7 @@ import { unauthorizedRedirect } from '@/app/libs/auth-redirect';
 import { removeDocumentSymbols } from '@/app/libs/parser';
 import { getCurrentUser } from '@/app/libs/session';
 import { fetchPartners } from '@/app/services/partners';
-import { Partner } from '@/app/types/partner';
+import { PartnerListItem } from '@/app/types/partner-list-item';
 import { SearchResponse } from '@/app/types/search_response';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
@@ -61,7 +61,7 @@ function prepareQuery(filters?: PartnerFilters): string {
 
 async function getData(
   filters?: PartnerFilters
-): Promise<SearchResponse<Partner>> {
+): Promise<SearchResponse<PartnerListItem>> {
   let { page, ...rest } = filters || {};
   page = page || 1;
 
@@ -75,12 +75,20 @@ async function getData(
     return { result: [], paging: { limit: 10, offset: page * 10, total: 0 } };
   }
 
-  const partners = data.result;
+  const listItems = data.result.map(
+    (p): PartnerListItem => ({
+      partner_id: p.partner_id,
+      first_name: p.first_name,
+      last_name: p.last_name,
+      partner_type: p.partner_type,
+      document: p.document,
+      city: p.shipping.city,
+      state: p.shipping.state,
+      active: p.active,
+    })
+  );
 
-  return {
-    result: partners,
-    paging: data.paging,
-  };
+  return { result: listItems, paging: data.paging };
 }
 
 export default async function Page({ searchParams }: PartnerPageParams) {

--- a/src/app/(authenticated)/users/page.tsx
+++ b/src/app/(authenticated)/users/page.tsx
@@ -2,6 +2,7 @@
 import UsersTable from '@/app/components/users/table';
 import { fetchUsers } from '@/app/services/user';
 import { getCurrentUser } from '@/app/libs/session';
+import { UserListItem } from '@/app/types/user-list-item';
 import { adminRoles } from '@/app/utils/roles';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
@@ -25,10 +26,27 @@ export default async function Page({ searchParams }: UserPageParams) {
     redirect('/home');
   }
 
-  const { data: users } = await fetchUsers(
+  const { data: usersData } = await fetchUsers(
     (query || '') + '&role=operator&role=admin&role=admin_operator',
     page || 1
   );
+
+  const users = usersData
+    ? {
+        result: usersData.result.map(
+          (u): UserListItem => ({
+            user_id: u.user_id,
+            username: u.username,
+            first_name: u.first_name,
+            last_name: u.last_name,
+            email: u.email,
+            role: u.role,
+            active: u.active,
+          })
+        ),
+        paging: usersData.paging,
+      }
+    : undefined;
 
   return (
     <main>

--- a/src/app/components/cases/form-details/customer_info.tsx
+++ b/src/app/components/cases/form-details/customer_info.tsx
@@ -5,15 +5,31 @@ import { CreateAttachment } from '@/app/types/attachments';
 import { CaseFull, CaseStatus } from '@/app/types/case';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import {
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  useRef,
+  useState,
+} from 'react';
 import { useActionState } from 'react';
 import { Button } from '../../common/button';
 import { Card } from '../../common/card';
 import { ErrorMessage } from '../../common/error-message';
-import {
+import dynamic from 'next/dynamic';
+import type {
   FileUploaderGenericRef,
-  GenericUploader,
+  FileUploaderProps,
 } from '../../common/file-uploader';
+
+const GenericUploader = dynamic(
+  () =>
+    import('../../common/file-uploader').then((m) => ({
+      default: m.GenericUploader,
+    })),
+  { ssr: false }
+) as ForwardRefExoticComponent<
+  FileUploaderProps & RefAttributes<FileUploaderGenericRef>
+>;
 
 interface CustomerInfoStatusFormProps {
   crmCase: CaseFull;

--- a/src/app/components/cases/form-details/ongoing_case.tsx
+++ b/src/app/components/cases/form-details/ongoing_case.tsx
@@ -7,14 +7,30 @@ import { CreateAttachment } from '@/app/types/attachments';
 import { CaseFull, CaseStatus } from '@/app/types/case';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import {
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  useRef,
+  useState,
+} from 'react';
 import { useActionState } from 'react';
 import { Button } from '../../common/button';
 import { Card } from '../../common/card';
-import {
+import dynamic from 'next/dynamic';
+import type {
   FileUploaderGenericRef,
-  GenericUploader,
+  FileUploaderProps,
 } from '../../common/file-uploader';
+
+const GenericUploader = dynamic(
+  () =>
+    import('../../common/file-uploader').then((m) => ({
+      default: m.GenericUploader,
+    })),
+  { ssr: false }
+) as ForwardRefExoticComponent<
+  FileUploaderProps & RefAttributes<FileUploaderGenericRef>
+>;
 import TargetDateModal from '../target-date-modal';
 import { ErrorMessage } from '../../common/error-message';
 import { RadioGroup, Radio } from '@heroui/react';

--- a/src/app/components/cases/table.tsx
+++ b/src/app/components/cases/table.tsx
@@ -1,12 +1,13 @@
 'use client';
+import { CaseListItem } from '@/app/types/case-list-item';
 import { SearchResponse } from '@/app/types/search_response';
 import { Pagination } from '@heroui/pagination';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { parseDateTime } from '../../libs/date';
-import { CaseFull, caseStatusMap } from '../../types/case';
+import { caseStatusMap } from '../../types/case';
 import { roboto } from '../../ui/fonts';
 import Modal from '../common/modal';
 import { CreateCaseBatchModal } from './batch-form-modal';
@@ -14,7 +15,7 @@ import CreateCaseModal from './create-case';
 import CasesSearchBar from './search-bar';
 
 interface CasesTableProps {
-  cases: SearchResponse<CaseFull>;
+  cases: SearchResponse<CaseListItem>;
   initialPage?: number;
 }
 
@@ -87,17 +88,17 @@ export default function CasesTable({ cases, initialPage }: CasesTableProps) {
                       </td>
                       <td className="whitespace-nowrap bg-white py-5 pl-4 pr-3 text-sm text-black group-first-of-type:rounded-md group-last-of-type:rounded-md sm:pl-6">
                         <div className="flex items-center gap-3">
-                          <p>{`${crmCase.customer?.first_name || '-'} ${crmCase.customer?.last_name || ''}`}</p>
+                          <p>{`${crmCase.customer_first_name || '-'} ${crmCase.customer_last_name || ''}`}</p>
                         </div>
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
-                        {crmCase.customer?.shipping.city || '-'}
+                        {crmCase.customer_city || '-'}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
-                        {crmCase.contractor?.company_name || '-'}
+                        {crmCase.contractor_company_name || '-'}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm group-first-of-type:rounded-md group-last-of-type:rounded-md">
-                        {crmCase.partner?.first_name || '-'}
+                        {crmCase.partner_first_name || '-'}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm group-first-of-type:rounded-md group-last-of-type:rounded-md">
                         {caseStatusMap[crmCase.status]}

--- a/src/app/components/common/file-uploader/index.tsx
+++ b/src/app/components/common/file-uploader/index.tsx
@@ -12,7 +12,7 @@ export interface FileUploaderGenericRef {
   length: number;
 }
 
-interface FileUploaderProps {
+export interface FileUploaderProps {
   maxFileSize?: number;
   maxFiles?: number;
   minFiles?: number;

--- a/src/app/components/contractors/table.tsx
+++ b/src/app/components/contractors/table.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { parseDateTime } from '@/app/libs/date';
 import { parseDocument } from '@/app/libs/parser';
+import { ContractorListItem } from '@/app/types/contractor-list-item';
 import { SearchResponse } from '@/app/types/search_response';
 import { EyeIcon } from '@heroicons/react/24/outline';
 import PencilIcon from '@heroicons/react/24/outline/PencilIcon';
@@ -10,14 +11,13 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import Modal from '../../components/common/modal';
 import ContractorsSearchBar from '../../components/contractors/search-bar';
-import { Contractor } from '../../types/contractor';
 import { roboto } from '../../ui/fonts';
 import CreateContractorModal from './create-contractor';
 import { DeleteContractorModal } from './delete-contractor';
 import EditContractorModal from './edit-contractor';
 
 interface ContractorsTableProps {
-  contractors?: SearchResponse<Contractor>;
+  contractors?: SearchResponse<ContractorListItem>;
   initialPage?: number;
 }
 

--- a/src/app/components/customers/table.tsx
+++ b/src/app/components/customers/table.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { parseDateTime } from '@/app/libs/date';
 import { parseDocument } from '@/app/libs/parser';
+import { CustomerListItem } from '@/app/types/customer-list-item';
 import { SearchResponse } from '@/app/types/search_response';
 import EyeIcon from '@heroicons/react/24/outline/EyeIcon';
 import PencilIcon from '@heroicons/react/24/outline/PencilIcon';
@@ -8,7 +9,6 @@ import TrashIcon from '@heroicons/react/24/outline/TrashIcon';
 import { Pagination } from '@heroui/pagination';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { Customer } from '../../types/customer';
 import { roboto } from '../../ui/fonts';
 import Modal from '../common/modal';
 import CreateCustomerModal from './create-customer';
@@ -17,7 +17,7 @@ import EditCustomerModal from './edit-customer';
 import CustomersSearchBar from './search-bar';
 
 interface CustomersTableProps {
-  customers?: SearchResponse<Customer>;
+  customers?: SearchResponse<CustomerListItem>;
   initialPage?: number;
 }
 
@@ -95,7 +95,7 @@ export default function CustomersTable({
                         </div>
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
-                        {customer.personal_contact?.email || '-'}
+                        {customer.email || '-'}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
                         {parseDocument(customer.document)}

--- a/src/app/components/dashboards/performance-chart-lazy.tsx
+++ b/src/app/components/dashboards/performance-chart-lazy.tsx
@@ -1,0 +1,12 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { ChartSkeleton } from './skeletons';
+
+const PerformanceChart = dynamic(() => import('./performance-chart'), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
+
+export default function PerformanceChartLazy() {
+  return <PerformanceChart />;
+}

--- a/src/app/components/panel/search.tsx
+++ b/src/app/components/panel/search.tsx
@@ -1,8 +1,10 @@
 'use client';
 import { brazilStates } from '@/app/types/address';
-import { Contractor } from '@/app/types/contractor';
 import { months } from '@/app/types/month';
-import { Partner } from '@/app/types/partner';
+import {
+  PanelContractorOption,
+  PanelPartnerOption,
+} from '@/app/types/panel-case-item';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '../common/button';
 import { Dropdown } from '../common/dropdown/dropdown';
@@ -12,8 +14,8 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import type { Key } from '@react-types/shared';
 
 interface ControlPanelSearchProps {
-  contractors: Contractor[];
-  partners?: Partner[];
+  contractors: PanelContractorOption[];
+  partners?: PanelPartnerOption[];
 }
 
 const currentYear = new Date().getFullYear();
@@ -164,7 +166,7 @@ export default function ControlPanelSearch({
           >
             {(item) => (
               <AutocompleteItem key={item.partner_id}>
-                {`${item.first_name} ${item.last_name} - ${item.shipping.city} / ${item.shipping.state}`}
+                {`${item.first_name} ${item.last_name}${item.city ? ` - ${item.city}` : ''}${item.state ? ` / ${item.state}` : ''}`}
               </AutocompleteItem>
             )}
           </Autocomplete>

--- a/src/app/components/panel/summary.tsx
+++ b/src/app/components/panel/summary.tsx
@@ -1,13 +1,13 @@
-"use server";
+'use server';
 
-import { parseToCurrency } from "@/app/libs/parser";
-import { CaseFull } from "@/app/types/case";
-import { Transaction, TransactionType } from "@/app/types/transaction";
-import { roboto } from "@/app/ui/fonts";
-import { Card } from "../common/card";
+import { parseToCurrency } from '@/app/libs/parser';
+import { PanelCaseItem } from '@/app/types/panel-case-item';
+import { TransactionType } from '@/app/types/transaction';
+import { roboto } from '@/app/ui/fonts';
+import { Card } from '../common/card';
 
 interface ControlPanelSummaryProps {
-  cases: CaseFull[];
+  cases: PanelCaseItem[];
 }
 
 interface PanelSummaryData {
@@ -21,7 +21,7 @@ interface PanelSummaryData {
   totalOutgoing: number;
 }
 
-async function getData(cases: CaseFull[]): Promise<PanelSummaryData> {
+async function getData(cases: PanelCaseItem[]): Promise<PanelSummaryData> {
   let totalLabor = 0;
   let totalDisplacement = 0;
   let totalParts = 0;
@@ -62,7 +62,7 @@ async function getData(cases: CaseFull[]): Promise<PanelSummaryData> {
             break;
         }
       }
-    })
+    });
   });
 
   return {
@@ -77,61 +77,81 @@ async function getData(cases: CaseFull[]): Promise<PanelSummaryData> {
   };
 }
 
-export default async function ControlPanelSummary({ cases }: ControlPanelSummaryProps) {
+export default async function ControlPanelSummary({
+  cases,
+}: ControlPanelSummaryProps) {
   const data = await getData(cases);
 
   return (
     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <Card title="Mão de obra Técnico">
-        <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalLabor)}
         </p>
       </Card>
 
       <Card title="Deslocamento Técnico">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalDisplacement)}
         </p>
       </Card>
 
       <Card title="Peças Técnico">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalParts)}
         </p>
       </Card>
 
       <Card title="Mão de obra Seguradora">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalIncomingLabor)}
         </p>
       </Card>
 
       <Card title="Deslocamento Seguradora">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalIncomingDisplacement)}
         </p>
       </Card>
 
       <Card title="Peças Seguradora">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalIncomingParts)}
         </p>
       </Card>
 
       <Card title="Total entrada">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalIncoming)}
         </p>
       </Card>
 
       <Card title="Total saída">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {parseToCurrency(data.totalOutgoing)}
         </p>
       </Card>
 
       <Card title="Total de casos">
-      <p className={`${roboto.className} truncate rounded-xl bg-white px-2 py-4 text-center font-semibold text-md`}>
+        <p
+          className={`${roboto.className} text-md truncate rounded-xl bg-white px-2 py-4 text-center font-semibold`}
+        >
           {cases.length}
         </p>
       </Card>

--- a/src/app/components/panel/table.tsx
+++ b/src/app/components/panel/table.tsx
@@ -1,13 +1,13 @@
 'use client';
+import { PanelCaseItem } from '@/app/types/panel-case-item';
 import { SearchResponse } from '@/app/types/search_response';
 
 import { parseDateTime } from '../../libs/date';
-import { CaseFull } from '../../types/case';
 import { parseToCurrency } from '@/app/libs/parser';
 import { TransactionType } from '@/app/types/transaction';
 
 interface ControlPanelTableProps {
-  cases: SearchResponse<CaseFull>;
+  cases: SearchResponse<PanelCaseItem>;
   hideTecnicoColumn?: boolean;
 }
 
@@ -22,7 +22,7 @@ export default function ControlPanelTable({
 
   const documentCounts = (cases?.result || []).reduce<Record<string, number>>(
     (acc, c) => {
-      const doc = c.customer?.document;
+      const doc = c.customer_document;
       if (doc) acc[doc] = (acc[doc] || 0) + 1;
       return acc;
     },
@@ -87,7 +87,7 @@ export default function ControlPanelTable({
         <tbody className="divide-y divide-gray-200 text-gray-900">
           {(cases?.result || []).map((crmCase) => {
             const isDuplicate = duplicateDocuments.has(
-              crmCase.customer?.document || ''
+              crmCase.customer_document || ''
             );
             return (
               <tr key={crmCase.case_id} className="group">
@@ -95,7 +95,7 @@ export default function ControlPanelTable({
                   {parseDateTime(crmCase?.created_at || '')}
                 </td>
                 <td className="whitespace-nowrap bg-white py-5 pl-6 text-sm">
-                  {crmCase.customer?.shipping.city || '-'}
+                  {crmCase.customer_city || '-'}
                 </td>
                 <td
                   className={
@@ -103,20 +103,20 @@ export default function ControlPanelTable({
                     (isDuplicate ? ' text-red-500' : '')
                   }
                 >
-                  {crmCase.customer
-                    ? `${crmCase.customer.first_name} ${crmCase.customer.last_name}`
+                  {crmCase.customer_first_name
+                    ? `${crmCase.customer_first_name} ${crmCase.customer_last_name}`
                     : '-'}
                 </td>
                 {!hideTecnicoColumn && (
                   <td className="whitespace-nowrap bg-white py-5 pl-6 text-sm group-first-of-type:rounded-md group-last-of-type:rounded-md">
-                    {crmCase.partner?.first_name || '-'}
+                    {crmCase.partner_first_name || '-'}
                   </td>
                 )}
                 <td className="whitespace-nowrap bg-white py-5 pl-6 text-sm">
                   {crmCase.external_reference || '-'}
                 </td>
                 <td className="whitespace-nowrap bg-white py-5 pl-6 text-sm">
-                  {crmCase.contractor?.company_name || '-'}
+                  {crmCase.contractor_company_name || '-'}
                 </td>
                 <td className="whitespace-nowrap bg-white py-5 pl-6 text-sm">
                   {parseToCurrency(

--- a/src/app/components/partners/table.tsx
+++ b/src/app/components/partners/table.tsx
@@ -5,8 +5,8 @@ import { Pagination } from '@heroui/pagination';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { useState } from 'react';
 
+import { PartnerListItem } from '@/app/types/partner-list-item';
 import { SearchResponse } from '@/app/types/search_response';
-import { Partner } from '../../types/partner';
 import { roboto } from '../../ui/fonts';
 import CreatePartnerModal from './create-partner';
 import { DeletePartnerModal } from './delete-partner';
@@ -14,7 +14,7 @@ import EditPartnerModal from './edit-partner';
 import PartnersSearchBar from './search-bar';
 
 interface PartnersTableProps {
-  partners?: SearchResponse<Partner>;
+  partners?: SearchResponse<PartnerListItem>;
   initialPage?: number;
 }
 
@@ -107,10 +107,10 @@ export default function PartnersTable({
                         {parseDocument(partner.document) || '-'}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
-                        {partner.shipping.city}
+                        {partner.city}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
-                        {partner.shipping.state}
+                        {partner.state}
                       </td>
                       <td className="whitespace-nowrap bg-white px-4 py-5 text-sm">
                         {partner.active ? 'Ativo' : 'Inativo'}

--- a/src/app/components/payments/confirm-payment.tsx
+++ b/src/app/components/payments/confirm-payment.tsx
@@ -5,15 +5,31 @@ import { CaseStatus } from '@/app/types/case';
 import { roboto } from '@/app/ui/fonts';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import {
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  useRef,
+  useState,
+} from 'react';
 import { useActionState } from 'react';
 import { useFormStatus } from 'react-dom';
 import { Button } from '../common/button';
 import { ErrorMessage } from '../common/error-message';
-import {
+import dynamic from 'next/dynamic';
+import type {
   FileUploaderGenericRef,
-  GenericUploader,
+  FileUploaderProps,
 } from '../common/file-uploader';
+
+const GenericUploader = dynamic(
+  () =>
+    import('../common/file-uploader').then((m) => ({
+      default: m.GenericUploader,
+    })),
+  { ssr: false }
+) as ForwardRefExoticComponent<
+  FileUploaderProps & RefAttributes<FileUploaderGenericRef>
+>;
 import Modal from '../common/modal';
 
 interface ConfirmPaymentModalProps {

--- a/src/app/components/users/table.tsx
+++ b/src/app/components/users/table.tsx
@@ -1,13 +1,14 @@
 'use client';
+import { UserListItem } from '@/app/types/user-list-item';
+import { UserRole } from '@/app/types/user';
 import { SearchResponse } from '@/app/types/search_response';
-import { User, UserRole } from '@/app/types/user';
 import { EyeIcon } from '@heroicons/react/24/outline';
 import { Pagination } from '@heroui/pagination';
 import { useRouter } from 'next/navigation';
 import { roboto } from '../../ui/fonts';
 
 interface UsersTableProps {
-  users?: SearchResponse<User>;
+  users?: SearchResponse<UserListItem>;
   initialPage?: number;
 }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,17 +1,7 @@
-import { getServerSession } from 'next-auth';
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 import LoginForm from '../components/login/login-form';
 import AcmeLogo from '../ui/acme-logo';
 
-export default async function LoginPage() {
-  const session = await getServerSession();
-  const jwt = (await cookies()).get('jwt')?.value;
-
-  if (session && jwt) {
-    redirect('/home');
-  }
-
+export default function LoginPage() {
   return (
     <main className="flex items-center justify-center md:h-screen">
       <div className="relative mx-auto flex w-full max-w-[400px] flex-col space-y-2.5 p-4 md:-mt-32">

--- a/src/app/types/case-list-item.ts
+++ b/src/app/types/case-list-item.ts
@@ -1,0 +1,13 @@
+import { CaseStatus } from './case';
+
+export type CaseListItem = {
+  case_id: string;
+  external_reference: string;
+  status: CaseStatus;
+  due_date: string;
+  customer_first_name?: string;
+  customer_last_name?: string;
+  customer_city?: string;
+  contractor_company_name?: string;
+  partner_first_name?: string;
+};

--- a/src/app/types/contractor-list-item.ts
+++ b/src/app/types/contractor-list-item.ts
@@ -1,0 +1,8 @@
+export type ContractorListItem = {
+  contractor_id: string;
+  company_name: string;
+  legal_name: string;
+  document: string;
+  created_at: string;
+  active: boolean;
+};

--- a/src/app/types/customer-list-item.ts
+++ b/src/app/types/customer-list-item.ts
@@ -1,0 +1,9 @@
+export type CustomerListItem = {
+  customer_id: string;
+  first_name: string;
+  last_name: string;
+  email?: string;
+  document: string;
+  created_at: string;
+  active: boolean;
+};

--- a/src/app/types/panel-case-item.ts
+++ b/src/app/types/panel-case-item.ts
@@ -1,0 +1,34 @@
+import { TransactionType } from './transaction';
+
+export type PanelTransactionItem = {
+  type: TransactionType;
+  description?: string;
+  value: number;
+};
+
+export type PanelCaseItem = {
+  case_id: string;
+  created_at: string;
+  type: string;
+  external_reference: string;
+  customer_document?: string;
+  customer_first_name?: string;
+  customer_last_name?: string;
+  customer_city?: string;
+  partner_first_name?: string;
+  contractor_company_name?: string;
+  transactions?: PanelTransactionItem[];
+};
+
+export type PanelContractorOption = {
+  contractor_id: string;
+  company_name: string;
+};
+
+export type PanelPartnerOption = {
+  partner_id: string;
+  first_name: string;
+  last_name: string;
+  city?: string;
+  state?: string;
+};

--- a/src/app/types/partner-list-item.ts
+++ b/src/app/types/partner-list-item.ts
@@ -1,0 +1,10 @@
+export type PartnerListItem = {
+  partner_id: string;
+  first_name: string;
+  last_name: string;
+  partner_type: string;
+  document: string;
+  city?: string;
+  state?: string;
+  active: boolean;
+};

--- a/src/app/types/user-list-item.ts
+++ b/src/app/types/user-list-item.ts
@@ -1,0 +1,11 @@
+import { UserRole } from './user';
+
+export type UserListItem = {
+  user_id: string;
+  username: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  role: UserRole;
+  active: boolean;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export function middleware(req: NextRequest) {
   const jwt = req.cookies.get('jwt');
+  const isLoginPage = req.nextUrl.pathname === '/login';
 
-  if (!jwt) {
+  if (jwt && isLoginPage) {
+    return NextResponse.redirect(new URL('/home', req.url));
+  }
+
+  if (!jwt && !isLoginPage) {
     req.cookies.delete(['next-auth.csrf-token', 'next-auth.session-token']);
     return NextResponse.redirect(new URL('/login', req.url));
   }
@@ -13,6 +18,7 @@ export function middleware(req: NextRequest) {
 
 export const config = {
   matcher: [
+    '/login',
     '/home/:path*',
     '/panel/:path*',
     '/cases/:path*',


### PR DESCRIPTION
## Summary

Conjunto de otimizações para reduzir a métrica de **Fast Origin Transfer** no tier gratuito da Vercel, aplicadas em quatro frentes independentes:

- **BFF Payload Projection**: server components mapeiam tipos completos da API para tipos de apresentação mínimos (`CaseListItem`, `CustomerListItem`, `PartnerListItem`, `ContractorListItem`, `UserListItem`, `PanelCaseItem`) antes de repassar aos client components. Reduz o RSC payload embutido no HTML em ~90%.

- **Cache-Control headers**: regras `private, max-age, stale-while-revalidate` por categoria de rota em `next.config.mjs`. Browser cacheia páginas autenticadas sem expor ao CDN.

- **Login page estático**: `getServerSession` removido de `/login` e lógica de redirect movida para o middleware — página aparece como `○` no build output.

- **Lazy loading com `next/dynamic`**: recharts isolado em wrapper client component com `{ ssr: false }`; uppy convertido para dynamic import nos 3 consumidores com type cast `ForwardRefExoticComponent` para preservar `ref` forwarding.

- **Bundle analyzer**: `@next/bundle-analyzer` instalado com script `npm run analyze` (`--no-turbopack`).

## Test plan

- [ ] `npm run build` passa sem erros TypeScript
- [ ] `/login` renderiza e redireciona corretamente usuários autenticados
- [ ] Listagens (cases, customers, partners, contractors, users, panel) exibem dados corretamente
- [ ] Formulários com upload de arquivo funcionam (ongoing_case, customer_info, confirm-payment)
- [ ] Dashboard exibe skeleton enquanto o gráfico de performance carrega
- [ ] `npm run analyze` gera relatório HTML dos bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)