### PR TITLE
feat: dashboard refactor with real data, TV mode and auto-redirect

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { middleware } from '../middleware';
+
+function buildRequest(
+  pathname: string,
+  options: { jwt?: string; userAgent?: string } = {}
+): NextRequest {
+  const url = `http://localhost${pathname}`;
+  const req = new NextRequest(url, {
+    headers: {
+      'user-agent': options.userAgent ?? 'Mozilla/5.0 (Windows NT 10.0)',
+    },
+  });
+  if (options.jwt) {
+    req.cookies.set('jwt', options.jwt);
+  }
+  return req;
+}
+
+const TV_USER_AGENTS = [
+  'Mozilla/5.0 (Linux; Android 9; AFT Build) AppleWebKit/537.36',
+  'Mozilla/5.0 (SMART-TV; Linux; Tizen 5.0)',
+  'Mozilla/5.0 (webOS/5.0; Linux/SmartTV)',
+  'Mozilla/5.0 (AppleTV; CPU TV OS 14_0)',
+  'Roku/DVP-9.10',
+  'Mozilla/5.0 (Linux; Android 9; CrKey) AppleWebKit/537.36',
+  'Mozilla/5.0 (Linux; Android 9; GoogleTV) AppleWebKit/537.36',
+  'Mozilla/5.0 (Linux; Android 9) Android TV AppleWebKit/537.36',
+];
+
+const BROWSER_USER_AGENTS = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X) Safari/537.36',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0) Mobile/15E148',
+];
+
+describe('middleware', () => {
+  describe('unauthenticated user', () => {
+    it('should redirect to /login when accessing a protected route', () => {
+      const req = buildRequest('/home');
+      const res = middleware(req);
+      expect(res?.headers.get('location')).toContain('/login');
+    });
+
+    it('should allow access to /login', () => {
+      const req = buildRequest('/login');
+      const res = middleware(req);
+      expect(res?.headers.get('location')).toBeNull();
+    });
+  });
+
+  describe('authenticated browser user', () => {
+    it('should redirect from /login to /home', () => {
+      const req = buildRequest('/login', { jwt: 'token' });
+      const res = middleware(req);
+      expect(res?.headers.get('location')).toContain('/home');
+    });
+
+    it('should not redirect from /home to /tv/dashboards', () => {
+      const req = buildRequest('/home', { jwt: 'token' });
+      const res = middleware(req);
+      expect(res?.headers.get('location')).toBeNull();
+    });
+  });
+
+  describe('authenticated TV device', () => {
+    TV_USER_AGENTS.forEach((ua) => {
+      it(`should redirect from /login to /tv/dashboards — ${ua.slice(0, 50)}`, () => {
+        const req = buildRequest('/login', { jwt: 'token', userAgent: ua });
+        const res = middleware(req);
+        expect(res?.headers.get('location')).toContain('/tv/dashboards');
+      });
+
+      it(`should redirect from /home to /tv/dashboards — ${ua.slice(0, 50)}`, () => {
+        const req = buildRequest('/home', { jwt: 'token', userAgent: ua });
+        const res = middleware(req);
+        expect(res?.headers.get('location')).toContain('/tv/dashboards');
+      });
+    });
+
+    BROWSER_USER_AGENTS.forEach((ua) => {
+      it(`should NOT detect as TV — ${ua.slice(0, 50)}`, () => {
+        const req = buildRequest('/login', { jwt: 'token', userAgent: ua });
+        const res = middleware(req);
+        expect(res?.headers.get('location')).not.toContain('/tv/dashboards');
+      });
+    });
+  });
+
+  describe('TV route protection', () => {
+    it('should redirect unauthenticated user from /tv/dashboards to /login', () => {
+      const req = buildRequest('/tv/dashboards');
+      const res = middleware(req);
+      expect(res?.headers.get('location')).toContain('/login');
+    });
+  });
+});

--- a/src/app/(authenticated)/dashboards/__tests__/page.test.tsx
+++ b/src/app/(authenticated)/dashboards/__tests__/page.test.tsx
@@ -12,11 +12,6 @@ jest.mock('../../../libs/session', () => ({
   getCurrentUser: jest.fn(),
 }));
 
-jest.mock('../../../components/dashboards/period-filter', () => ({
-  __esModule: true,
-  default: () => <div data-testid="period-filter" />,
-}));
-
 jest.mock('../../../components/dashboards/kpi-cards', () => ({
   __esModule: true,
   default: () => <div data-testid="kpi-cards" />,
@@ -27,9 +22,9 @@ jest.mock('../../../components/dashboards/ranking', () => ({
   default: () => <div data-testid="ranking" />,
 }));
 
-jest.mock('../../../components/dashboards/achievements', () => ({
+jest.mock('../../../components/dashboards/attendance-bonus', () => ({
   __esModule: true,
-  default: () => <div data-testid="achievements" />,
+  default: () => <div data-testid="attendance-bonus" />,
 }));
 
 jest.mock('../../../components/dashboards/performance-chart', () => ({
@@ -37,16 +32,13 @@ jest.mock('../../../components/dashboards/performance-chart', () => ({
   default: () => <div data-testid="performance-chart" />,
 }));
 
-jest.mock('../../../components/dashboards/rewards', () => ({
-  __esModule: true,
-  default: () => <div data-testid="rewards" />,
-}));
-
 jest.mock('../../../components/dashboards/skeletons', () => ({
   KpiCardsSkeleton: () => <div data-testid="kpi-cards-skeleton" />,
   RankingSkeleton: () => <div data-testid="ranking-skeleton" />,
   ChartSkeleton: () => <div data-testid="chart-skeleton" />,
-  GenericSkeleton: () => <div data-testid="generic-skeleton" />,
+  AttendanceBonusSkeleton: () => (
+    <div data-testid="attendance-bonus-skeleton" />
+  ),
 }));
 
 jest.mock('@heroicons/react/24/outline', () => ({
@@ -89,14 +81,9 @@ describe('Page', () => {
       render(await Page());
       expect(
         screen.getByText(
-          'Acompanhe rankings, conquistas e evolução no atendimento'
+          'Acompanhe rankings, assiduidade e evolução no atendimento'
         )
       ).toBeInTheDocument();
-    });
-
-    it('should render the period filter', async () => {
-      render(await Page());
-      expect(screen.getByTestId('period-filter')).toBeInTheDocument();
     });
 
     it('should render the KPI cards', async () => {
@@ -109,19 +96,14 @@ describe('Page', () => {
       expect(screen.getByTestId('ranking')).toBeInTheDocument();
     });
 
-    it('should render the achievements', async () => {
+    it('should render the attendance bonus board', async () => {
       render(await Page());
-      expect(screen.getByTestId('achievements')).toBeInTheDocument();
+      expect(screen.getByTestId('attendance-bonus')).toBeInTheDocument();
     });
 
     it('should render the performance chart', async () => {
       render(await Page());
       expect(screen.getByTestId('performance-chart')).toBeInTheDocument();
-    });
-
-    it('should render the rewards', async () => {
-      render(await Page());
-      expect(screen.getByTestId('rewards')).toBeInTheDocument();
     });
   });
 });

--- a/src/app/(authenticated)/dashboards/page.tsx
+++ b/src/app/(authenticated)/dashboards/page.tsx
@@ -1,12 +1,11 @@
 'use server';
-import Achievements from '@/app/components/dashboards/achievements';
+import AttendanceBonus from '@/app/components/dashboards/attendance-bonus';
 import KpiCards from '@/app/components/dashboards/kpi-cards';
 import PerformanceChartLazy from '@/app/components/dashboards/performance-chart-lazy';
-import PeriodFilter from '@/app/components/dashboards/period-filter';
 import Ranking from '@/app/components/dashboards/ranking';
-import Rewards from '@/app/components/dashboards/rewards';
 import {
-  GenericSkeleton,
+  AttendanceBonusSkeleton,
+  ChartSkeleton,
   KpiCardsSkeleton,
   RankingSkeleton,
 } from '@/app/components/dashboards/skeletons';
@@ -29,24 +28,21 @@ export default async function Page() {
 
   return (
     <main className="flex flex-col gap-6">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <div className="flex items-center gap-2">
-            <TrophyIcon className="h-6 w-6 text-amber-500" />
-            <h1 className="text-xl font-bold text-gray-900 md:text-2xl">
-              Desempenho do Time
-            </h1>
-          </div>
-          <p className="mt-0.5 text-sm text-gray-500">
-            Acompanhe rankings, conquistas e evolução no atendimento
-          </p>
+      <div>
+        <div className="flex items-center gap-2">
+          <TrophyIcon className="h-6 w-6 text-amber-500" />
+          <h1 className="text-xl font-bold text-gray-900 md:text-2xl">
+            Desempenho do Time
+          </h1>
         </div>
-        <PeriodFilter />
+        <p className="mt-0.5 text-sm text-gray-500">
+          Acompanhe rankings, assiduidade e evolução no atendimento
+        </p>
       </div>
 
       <Suspense
         fallback={
-          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <div className="grid grid-cols-2 gap-4">
             <KpiCardsSkeleton />
           </div>
         }
@@ -58,16 +54,15 @@ export default async function Page() {
         <Suspense fallback={<RankingSkeleton />}>
           <Ranking />
         </Suspense>
-        <Suspense fallback={<GenericSkeleton />}>
-          <Achievements />
-        </Suspense>
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <PerformanceChartLazy />
-        <Suspense fallback={<GenericSkeleton />}>
-          <Rewards />
-        </Suspense>
+        
+        <div className="flex flex-col gap-4">
+          <Suspense fallback={<AttendanceBonusSkeleton />}>
+            <AttendanceBonus />
+          </Suspense>
+          <Suspense fallback={<ChartSkeleton />}>
+            <PerformanceChartLazy />
+          </Suspense>
+        </div>
       </div>
     </main>
   );

--- a/src/app/components/dashboards/__tests__/attendance-bonus.test.tsx
+++ b/src/app/components/dashboards/__tests__/attendance-bonus.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import AttendanceBonus from '../attendance-bonus';
+
+const mockEmployees = [
+  'João Silva',
+  'Maria Oliveira',
+  'Daniel Costa',
+  'Ana Ferreira',
+];
+
+describe('AttendanceBonus', () => {
+  describe('rendering', () => {
+    it('should render the section title', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      expect(screen.getByText('Bônus Assiduidade')).toBeInTheDocument();
+    });
+
+    it('should render the bonus badge', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      expect(screen.getByText('R$ 200,00')).toBeInTheDocument();
+    });
+
+    it('should render all employee first names', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      expect(screen.getByText('João')).toBeInTheDocument();
+      expect(screen.getByText('Maria')).toBeInTheDocument();
+      expect(screen.getByText('Daniel')).toBeInTheDocument();
+      expect(screen.getByText('Ana')).toBeInTheDocument();
+    });
+
+    it('should show all employees as active initially', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      expect(screen.getByText(`${mockEmployees.length}`)).toBeInTheDocument();
+    });
+
+    it('should render empty state with no employees', () => {
+      render(<AttendanceBonus employees={[]} />);
+      expect(screen.getByText('Bônus Assiduidade')).toBeInTheDocument();
+    });
+  });
+
+  describe('interaction', () => {
+    it('should mark an employee as eliminated when clicked', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      fireEvent.click(screen.getByTitle('Eliminar João Silva'));
+      expect(screen.getByTitle('Reativar João Silva')).toBeInTheDocument();
+    });
+
+    it('should reactivate an eliminated employee when clicked again', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      fireEvent.click(screen.getByTitle('Eliminar João Silva'));
+      fireEvent.click(screen.getByTitle('Reativar João Silva'));
+      expect(screen.getByTitle('Eliminar João Silva')).toBeInTheDocument();
+    });
+
+    it('should update the active count when an employee is eliminated', () => {
+      render(<AttendanceBonus employees={mockEmployees} />);
+      fireEvent.click(screen.getByTitle('Eliminar João Silva'));
+      expect(
+        screen.getByText(`${mockEmployees.length - 1}`)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/components/dashboards/__tests__/kpi-cards.test.tsx
+++ b/src/app/components/dashboards/__tests__/kpi-cards.test.tsx
@@ -1,39 +1,77 @@
 import { render, screen } from '@testing-library/react';
 import KpiCards from '../kpi-cards';
 
+jest.mock('../../../services/cases/fetch_dashboard_kpis', () => ({
+  fetchDashboardKpis: jest.fn(),
+}));
+
+const { fetchDashboardKpis } = jest.requireMock(
+  '../../../services/cases/fetch_dashboard_kpis'
+);
+
+const mockKpis = {
+  success: true,
+  message: '',
+  data: {
+    closedHistory: [
+      { month: 'Abr', count: 82 },
+      { month: 'Mai', count: 88 },
+      { month: 'Jun', count: 102 },
+    ],
+    slaPercentage: 94.2,
+    slaGoal: 90,
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchDashboardKpis.mockResolvedValue(mockKpis);
+});
+
 describe('KpiCards', () => {
   describe('rendering', () => {
-    it('should render all four KPI card titles', () => {
-      render(<KpiCards />);
+    it('should render all KPI card titles', async () => {
+      render(await KpiCards());
       expect(screen.getByText('Casos Finalizados')).toBeInTheDocument();
       expect(screen.getByText('SLA no Prazo')).toBeInTheDocument();
-      expect(screen.getByText('Satisfação do Cliente')).toBeInTheDocument();
-      expect(screen.getByText('Pontos do Time')).toBeInTheDocument();
     });
 
-    it('should render the closed cases count', () => {
-      render(<KpiCards />);
+    it('should render the closed cases count from the latest month', async () => {
+      render(await KpiCards());
       expect(screen.getByText('102')).toBeInTheDocument();
     });
 
-    it('should render the SLA percentage', () => {
-      render(<KpiCards />);
-      expect(screen.getByText('96%')).toBeInTheDocument();
+    it('should render the SLA percentage', async () => {
+      render(await KpiCards());
+      expect(screen.getByText('94.2%')).toBeInTheDocument();
     });
 
-    it('should render the team points value', () => {
-      render(<KpiCards />);
-      expect(screen.getByText('3.650')).toBeInTheDocument();
+    it('should render the positive trend indicator for closed cases', async () => {
+      render(await KpiCards());
+      expect(screen.getByText(/\+\d+% vs mês anterior/)).toBeInTheDocument();
     });
 
-    it('should render the positive trend indicator for closed cases', () => {
-      render(<KpiCards />);
-      expect(screen.getByText('+ 12% vs semana passada')).toBeInTheDocument();
+    it('should render the SLA goal as achieved', async () => {
+      render(await KpiCards());
+      expect(screen.getByText(/Meta:/)).toBeInTheDocument();
+      expect(screen.getByText(/Atingida/)).toBeInTheDocument();
     });
 
-    it('should render the client satisfaction score', () => {
-      render(<KpiCards />);
-      expect(screen.getByText('4.0 / 5.0')).toBeInTheDocument();
+    it('should render mini history bars for the last 3 months', async () => {
+      render(await KpiCards());
+      expect(screen.getByText('Abr')).toBeInTheDocument();
+      expect(screen.getByText('Mai')).toBeInTheDocument();
+      expect(screen.getByText('Jun')).toBeInTheDocument();
+    });
+
+    it('should render fallback values when service fails', async () => {
+      fetchDashboardKpis.mockResolvedValue({
+        success: false,
+        message: 'error',
+      });
+      render(await KpiCards());
+      expect(screen.getByText('0')).toBeInTheDocument();
+      expect(screen.getByText('0%')).toBeInTheDocument();
     });
   });
 });

--- a/src/app/components/dashboards/__tests__/performance-chart.test.tsx
+++ b/src/app/components/dashboards/__tests__/performance-chart.test.tsx
@@ -18,34 +18,43 @@ jest.mock('recharts', () => ({
   Legend: () => <div data-testid="legend" />,
 }));
 
+const mockData = [
+  { week: 'S1', tma: 4.2, volume: 38 },
+  { week: 'S2', tma: 3.8, volume: 42 },
+  { week: 'S3', tma: 5.1, volume: 55 },
+  { week: 'S4', tma: 4.6, volume: 50 },
+  { week: 'S5', tma: 3.5, volume: 44 },
+  { week: 'S6', tma: 3.2, volume: 47 },
+];
+
 describe('PerformanceChart', () => {
   describe('rendering', () => {
     it('should render the section title', () => {
-      render(<PerformanceChart />);
+      render(<PerformanceChart data={mockData} />);
       expect(
         screen.getByText('Evolução de Desempenho (TMA)')
       ).toBeInTheDocument();
     });
 
     it('should render the subtitle', () => {
-      render(<PerformanceChart />);
+      render(<PerformanceChart data={mockData} />);
       expect(
         screen.getByText('Tempo Médio de Atendimento vs Volume Recebido')
       ).toBeInTheDocument();
     });
 
     it('should render the chart container', () => {
-      render(<PerformanceChart />);
+      render(<PerformanceChart data={mockData} />);
       expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     });
 
     it('should render the TMA line', () => {
-      render(<PerformanceChart />);
+      render(<PerformanceChart data={mockData} />);
       expect(screen.getByTestId('line-tma')).toBeInTheDocument();
     });
 
     it('should render the volume line', () => {
-      render(<PerformanceChart />);
+      render(<PerformanceChart data={mockData} />);
       expect(screen.getByTestId('line-volume')).toBeInTheDocument();
     });
   });

--- a/src/app/components/dashboards/__tests__/performance-chart.test.tsx
+++ b/src/app/components/dashboards/__tests__/performance-chart.test.tsx
@@ -22,12 +22,16 @@ describe('PerformanceChart', () => {
   describe('rendering', () => {
     it('should render the section title', () => {
       render(<PerformanceChart />);
-      expect(screen.getByText('Evolução de Desempenho')).toBeInTheDocument();
+      expect(
+        screen.getByText('Evolução de Desempenho (TMA)')
+      ).toBeInTheDocument();
     });
 
-    it('should render the "Ver Histórico" action link', () => {
+    it('should render the subtitle', () => {
       render(<PerformanceChart />);
-      expect(screen.getByText(/Ver Histórico/)).toBeInTheDocument();
+      expect(
+        screen.getByText('Tempo Médio de Atendimento vs Volume Recebido')
+      ).toBeInTheDocument();
     });
 
     it('should render the chart container', () => {
@@ -35,19 +39,14 @@ describe('PerformanceChart', () => {
       expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     });
 
-    it('should render the line for cases data', () => {
+    it('should render the TMA line', () => {
       render(<PerformanceChart />);
-      expect(screen.getByTestId('line-cases')).toBeInTheDocument();
+      expect(screen.getByTestId('line-tma')).toBeInTheDocument();
     });
 
-    it('should render the line for SLA data', () => {
+    it('should render the volume line', () => {
       render(<PerformanceChart />);
-      expect(screen.getByTestId('line-sla')).toBeInTheDocument();
-    });
-
-    it('should render the line for points data', () => {
-      render(<PerformanceChart />);
-      expect(screen.getByTestId('line-points')).toBeInTheDocument();
+      expect(screen.getByTestId('line-volume')).toBeInTheDocument();
     });
   });
 });

--- a/src/app/components/dashboards/__tests__/ranking.test.tsx
+++ b/src/app/components/dashboards/__tests__/ranking.test.tsx
@@ -1,62 +1,112 @@
 import { render, screen } from '@testing-library/react';
 import Ranking from '../ranking';
 
+jest.mock('../../../services/cases/fetch_ranking', () => ({
+  fetchRankingData: jest.fn(),
+}));
+
+const { fetchRankingData } = jest.requireMock(
+  '../../../services/cases/fetch_ranking'
+);
+
+const mockAgents = [
+  {
+    name: 'João Silva',
+    inProgress: { green: 8, yellow: 3, red: 2, mostDelayed: 'CASO-099' },
+    finalized: { vistoria: 20, reparo: 14 },
+  },
+  {
+    name: 'Maria Oliveira',
+    inProgress: { green: 6, yellow: 4, red: 1, mostDelayed: 'CASO-074' },
+    finalized: { vistoria: 15, reparo: 13 },
+  },
+  {
+    name: 'Daniel Costa',
+    inProgress: { green: 5, yellow: 2, red: 3, mostDelayed: 'CASO-051' },
+    finalized: { vistoria: 12, reparo: 9 },
+  },
+  {
+    name: 'Ana Ferreira',
+    inProgress: { green: 4, yellow: 5, red: 0, mostDelayed: '' },
+    finalized: { vistoria: 10, reparo: 8 },
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchRankingData.mockResolvedValue({
+    success: true,
+    message: '',
+    data: mockAgents,
+  });
+});
+
 describe('Ranking', () => {
   describe('rendering', () => {
-    it('should render the section title', () => {
-      render(<Ranking />);
+    it('should render the section title', async () => {
+      render(await Ranking());
       expect(screen.getByText('Ranking – Atendimento')).toBeInTheDocument();
     });
 
-    it('should render the "Ver Todos" action link', () => {
-      render(<Ranking />);
+    it('should render the "Ver Todos" action link', async () => {
+      render(await Ranking());
       expect(screen.getByText('Ver Todos')).toBeInTheDocument();
     });
 
-    it('should render the bonus banner', () => {
-      render(<Ranking />);
+    it('should render the bonus banner', async () => {
+      render(await Ranking());
       expect(screen.getByText(/Bônus Liderança Geral/)).toBeInTheDocument();
       expect(screen.getByText(/R\$ 400,00/)).toBeInTheDocument();
     });
 
-    it('should render all four agents by first name', () => {
-      render(<Ranking />);
+    it('should render all agents by first name', async () => {
+      render(await Ranking());
       expect(screen.getByText('João')).toBeInTheDocument();
       expect(screen.getByText('Maria')).toBeInTheDocument();
       expect(screen.getByText('Daniel')).toBeInTheDocument();
       expect(screen.getByText('Ana')).toBeInTheDocument();
     });
 
-    it('should render gold medal for first place', () => {
-      render(<Ranking />);
+    it('should render gold medal for first place', async () => {
+      render(await Ranking());
       expect(screen.getByText('🥇')).toBeInTheDocument();
     });
 
-    it('should render silver medal for second place', () => {
-      render(<Ranking />);
+    it('should render silver medal for second place', async () => {
+      render(await Ranking());
       expect(screen.getByText('🥈')).toBeInTheDocument();
     });
 
-    it('should render bronze medal for third place', () => {
-      render(<Ranking />);
+    it('should render bronze medal for third place', async () => {
+      render(await Ranking());
       expect(screen.getByText('🥉')).toBeInTheDocument();
     });
 
-    it('should render numeric position for fourth place', () => {
-      render(<Ranking />);
+    it('should render numeric position for fourth place', async () => {
+      render(await Ranking());
       const matches = screen.getAllByText('4');
       expect(matches.length).toBeGreaterThan(0);
     });
 
-    it('should render the delay traffic light labels', () => {
-      render(<Ranking />);
+    it('should render the delay traffic light labels', async () => {
+      render(await Ranking());
       const labels = screen.getAllByText(/≤5d/);
       expect(labels.length).toBeGreaterThan(0);
     });
 
-    it('should render the most delayed case number', () => {
-      render(<Ranking />);
+    it('should render the most delayed case number', async () => {
+      render(await Ranking());
       expect(screen.getByText(/CASO-099/)).toBeInTheDocument();
+    });
+
+    it('should render an empty state when service returns no agents', async () => {
+      fetchRankingData.mockResolvedValue({
+        success: true,
+        message: '',
+        data: [],
+      });
+      const { container } = render(await Ranking());
+      expect(container.querySelector('.grid')).toBeTruthy();
     });
   });
 });

--- a/src/app/components/dashboards/__tests__/ranking.test.tsx
+++ b/src/app/components/dashboards/__tests__/ranking.test.tsx
@@ -13,12 +13,18 @@ describe('Ranking', () => {
       expect(screen.getByText('Ver Todos')).toBeInTheDocument();
     });
 
-    it('should render all four agents', () => {
+    it('should render the bonus banner', () => {
       render(<Ranking />);
-      expect(screen.getByText('D')).toBeInTheDocument();
-      expect(screen.getByText('M')).toBeInTheDocument();
-      expect(screen.getByText('J')).toBeInTheDocument();
-      expect(screen.getByText('A')).toBeInTheDocument();
+      expect(screen.getByText(/Bônus Liderança Geral/)).toBeInTheDocument();
+      expect(screen.getByText(/R\$ 400,00/)).toBeInTheDocument();
+    });
+
+    it('should render all four agents by first name', () => {
+      render(<Ranking />);
+      expect(screen.getByText('João')).toBeInTheDocument();
+      expect(screen.getByText('Maria')).toBeInTheDocument();
+      expect(screen.getByText('Daniel')).toBeInTheDocument();
+      expect(screen.getByText('Ana')).toBeInTheDocument();
     });
 
     it('should render gold medal for first place', () => {
@@ -38,13 +44,19 @@ describe('Ranking', () => {
 
     it('should render numeric position for fourth place', () => {
       render(<Ranking />);
-      expect(screen.getByText('4')).toBeInTheDocument();
+      const matches = screen.getAllByText('4');
+      expect(matches.length).toBeGreaterThan(0);
     });
 
-    it('should render the table column headers', () => {
+    it('should render the delay traffic light labels', () => {
       render(<Ranking />);
-      expect(screen.getByText('FINALIZADOS')).toBeInTheDocument();
-      expect(screen.getByText('VIST. / REPARO')).toBeInTheDocument();
+      const labels = screen.getAllByText(/≤5d/);
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    it('should render the most delayed case number', () => {
+      render(<Ranking />);
+      expect(screen.getByText(/CASO-099/)).toBeInTheDocument();
     });
   });
 });

--- a/src/app/components/dashboards/__tests__/skeletons.test.tsx
+++ b/src/app/components/dashboards/__tests__/skeletons.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import {
+  AttendanceBonusSkeleton,
   ChartSkeleton,
   GenericSkeleton,
   KpiCardsSkeleton,
@@ -8,10 +9,10 @@ import {
 
 describe('Skeletons', () => {
   describe('KpiCardsSkeleton', () => {
-    it('should render four skeleton cards', () => {
+    it('should render two skeleton cards', () => {
       const { container } = render(<KpiCardsSkeleton />);
       const skeletonCards = container.querySelectorAll('.rounded-xl');
-      expect(skeletonCards).toHaveLength(4);
+      expect(skeletonCards).toHaveLength(2);
     });
   });
 
@@ -38,6 +39,19 @@ describe('Skeletons', () => {
       const { container } = render(<ChartSkeleton />);
       const chartArea = container.querySelector('.h-48');
       expect(chartArea).toBeInTheDocument();
+    });
+  });
+
+  describe('AttendanceBonusSkeleton', () => {
+    it('should render without crashing', () => {
+      const { container } = render(<AttendanceBonusSkeleton />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('should render twelve avatar placeholders', () => {
+      const { container } = render(<AttendanceBonusSkeleton />);
+      const avatars = container.querySelectorAll('.rounded-full');
+      expect(avatars.length).toBeGreaterThanOrEqual(12);
     });
   });
 

--- a/src/app/components/dashboards/attendance-bonus-server.tsx
+++ b/src/app/components/dashboards/attendance-bonus-server.tsx
@@ -1,0 +1,10 @@
+import { fetchOperators } from '@/app/services/users/fetch_operators';
+import AttendanceBonus from './attendance-bonus';
+
+export default async function AttendanceBonusServer() {
+  const result = await fetchOperators();
+  const employees = (result.data ?? []).map((u) =>
+    `${u.first_name} ${u.last_name}`.trim()
+  );
+  return <AttendanceBonus employees={employees} />;
+}

--- a/src/app/components/dashboards/attendance-bonus.tsx
+++ b/src/app/components/dashboards/attendance-bonus.tsx
@@ -30,25 +30,12 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
-const EMPLOYEES = [
-  'João Silva',
-  'Maria Oliveira',
-  'Daniel Costa',
-  'Ana Ferreira',
-  'Carlos Souza',
-  'Fernanda Lima',
-  'Ricardo Alves',
-  'Patrícia Mendes',
-  'Bruno Santos',
-  'Juliana Rocha',
-  'Marcos Pereira',
-  'Camila Nunes',
-];
-
-const INITIAL_ELIMINATED = new Set([2, 7]);
-
-export default function AttendanceBonus() {
-  const [eliminated, setEliminated] = useState<Set<number>>(INITIAL_ELIMINATED);
+export default function AttendanceBonus({
+  employees,
+}: {
+  employees: string[];
+}) {
+  const [eliminated, setEliminated] = useState<Set<number>>(new Set());
 
   function toggle(index: number) {
     setEliminated((prev) => {
@@ -62,7 +49,7 @@ export default function AttendanceBonus() {
     });
   }
 
-  const active = EMPLOYEES.length - eliminated.size;
+  const active = employees.length - eliminated.size;
 
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-gray-50 p-4 shadow-sm">
@@ -85,7 +72,7 @@ export default function AttendanceBonus() {
       </div>
 
       <div className="grid grid-cols-4 gap-3">
-        {EMPLOYEES.map((name, idx) => {
+        {employees.map((name, idx) => {
           const isEliminated = eliminated.has(idx);
           return (
             <button

--- a/src/app/components/dashboards/attendance-bonus.tsx
+++ b/src/app/components/dashboards/attendance-bonus.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+
+const AVATAR_COLORS = [
+  'bg-blue-500',
+  'bg-emerald-500',
+  'bg-violet-500',
+  'bg-rose-500',
+  'bg-amber-600',
+  'bg-cyan-600',
+  'bg-pink-500',
+  'bg-teal-500',
+  'bg-indigo-500',
+  'bg-orange-500',
+  'bg-lime-600',
+  'bg-sky-500',
+];
+
+function getAvatarColor(name: string, index: number): string {
+  return AVATAR_COLORS[index % AVATAR_COLORS.length];
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+const EMPLOYEES = [
+  'João Silva',
+  'Maria Oliveira',
+  'Daniel Costa',
+  'Ana Ferreira',
+  'Carlos Souza',
+  'Fernanda Lima',
+  'Ricardo Alves',
+  'Patrícia Mendes',
+  'Bruno Santos',
+  'Juliana Rocha',
+  'Marcos Pereira',
+  'Camila Nunes',
+];
+
+const INITIAL_ELIMINATED = new Set([2, 7]);
+
+export default function AttendanceBonus() {
+  const [eliminated, setEliminated] = useState<Set<number>>(INITIAL_ELIMINATED);
+
+  function toggle(index: number) {
+    setEliminated((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  }
+
+  const active = EMPLOYEES.length - eliminated.size;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl bg-gray-50 p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold text-gray-800">Bônus Assiduidade</span>
+        <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-bold text-amber-700">
+          R$ 200,00
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between text-xs text-gray-500">
+        <span>
+          <span className="font-semibold text-emerald-600">{active}</span>{' '}
+          ativos &nbsp;·&nbsp;
+          <span className="font-semibold text-gray-400">
+            {eliminated.size}
+          </span>{' '}
+          eliminados
+        </span>
+      </div>
+
+      <div className="grid grid-cols-4 gap-3">
+        {EMPLOYEES.map((name, idx) => {
+          const isEliminated = eliminated.has(idx);
+          return (
+            <button
+              key={name}
+              onClick={() => toggle(idx)}
+              className="group flex flex-col items-center gap-1"
+              title={isEliminated ? `Reativar ${name}` : `Eliminar ${name}`}
+            >
+              <div className="relative">
+                <div
+                  className={[
+                    'flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold text-white transition-all',
+                    getAvatarColor(name, idx),
+                    isEliminated
+                      ? 'ring-2 ring-gray-300 grayscale'
+                      : 'ring-2 ring-green-400 ring-offset-1',
+                  ].join(' ')}
+                >
+                  {getInitials(name)}
+                </div>
+                {isEliminated && (
+                  <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/30">
+                    <span className="text-base font-bold text-white">✕</span>
+                  </div>
+                )}
+              </div>
+              <span
+                className={`max-w-full truncate text-[10px] leading-tight ${isEliminated ? 'text-gray-400 line-through' : 'text-gray-600'}`}
+              >
+                {name.split(' ')[0]}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="text-center text-[10px] text-gray-400">
+        Clique no avatar para registrar ausência ou atraso
+      </p>
+    </div>
+  );
+}

--- a/src/app/components/dashboards/kpi-cards.tsx
+++ b/src/app/components/dashboards/kpi-cards.tsx
@@ -1,11 +1,27 @@
 import {
-  ClockIcon,
-  FaceSmileIcon,
-  FireIcon,
-  StarIcon,
-  TrophyIcon,
-} from '@heroicons/react/24/outline';
-import { StarIcon as StarSolid } from '@heroicons/react/24/solid';
+  fetchDashboardKpis,
+  MonthlyClosedCount,
+} from '@/app/services/cases/fetch_dashboard_kpis';
+import { ClockIcon, FireIcon } from '@heroicons/react/24/outline';
+
+function MiniHistoryBars({ history }: { history: MonthlyClosedCount[] }) {
+  const max = Math.max(...history.map((d) => d.count), 1);
+  return (
+    <div className="flex items-end gap-1.5">
+      {history.map((d) => (
+        <div key={d.month} className="flex flex-col items-center gap-1">
+          <div
+            className="w-6 rounded-t bg-blue-400"
+            style={{
+              height: `${Math.max(Math.round((d.count / max) * 32), 4)}px`,
+            }}
+          />
+          <span className="text-[10px] text-gray-400">{d.month}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function KpiCard({ children }: { children: React.ReactNode }) {
   return (
@@ -15,7 +31,11 @@ function KpiCard({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ClosedCasesCard() {
+function ClosedCasesCard({ history }: { history: MonthlyClosedCount[] }) {
+  const current = history[history.length - 1]?.count ?? 0;
+  const prev = history[history.length - 2]?.count ?? 0;
+  const pct = prev > 0 ? Math.round(((current - prev) / prev) * 100) : 0;
+
   return (
     <KpiCard>
       <div className="flex items-center gap-2">
@@ -24,15 +44,31 @@ function ClosedCasesCard() {
           Casos Finalizados
         </span>
       </div>
-      <p className="text-3xl font-bold text-gray-900">102</p>
-      <p className="text-xs font-medium text-emerald-600">
-        + 12% vs semana passada
-      </p>
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-3xl font-bold text-gray-900">{current}</p>
+          <p
+            className={`text-xs font-medium ${pct >= 0 ? 'text-emerald-600' : 'text-red-500'}`}
+          >
+            {pct >= 0 ? '+' : ''}
+            {pct}% vs mês anterior ({prev} casos)
+          </p>
+        </div>
+        <MiniHistoryBars history={history} />
+      </div>
     </KpiCard>
   );
 }
 
-function SlaOnTimeCard() {
+function SlaOnTimeCard({
+  slaPercentage,
+  slaGoal,
+}: {
+  slaPercentage: number;
+  slaGoal: number;
+}) {
+  const achieved = slaPercentage >= slaGoal;
+
   return (
     <KpiCard>
       <div className="flex items-center gap-2">
@@ -41,58 +77,44 @@ function SlaOnTimeCard() {
           SLA no Prazo
         </span>
       </div>
-      <p className="text-3xl font-bold text-gray-900">96%</p>
-      <div className="h-2 w-full rounded-full bg-gray-200">
-        <div
-          className="h-2 rounded-full bg-emerald-500"
-          style={{ width: '96%' }}
-        />
+      <p className="text-3xl font-bold text-gray-900">{slaPercentage}%</p>
+      <div className="flex flex-col gap-1">
+        <div className="h-2 w-full rounded-full bg-gray-200">
+          <div
+            className={`h-2 rounded-full ${achieved ? 'bg-emerald-500' : 'bg-amber-400'}`}
+            style={{ width: `${Math.min(slaPercentage, 100)}%` }}
+          />
+        </div>
+        <p className="text-xs text-gray-500">
+          Meta: {slaGoal}%{' '}
+          {achieved ? (
+            <span className="font-semibold text-emerald-600">✓ Atingida</span>
+          ) : (
+            <span className="font-semibold text-amber-600">
+              ⚠ Abaixo da meta
+            </span>
+          )}
+        </p>
       </div>
     </KpiCard>
   );
 }
 
-function ClientSatisfactionCard() {
-  return (
-    <KpiCard>
-      <div className="flex items-center gap-2">
-        <FaceSmileIcon className="h-5 w-5 text-yellow-500" />
-        <span className="text-sm font-semibold text-gray-600">
-          Satisfação do Cliente
-        </span>
-      </div>
-      <div className="flex items-center gap-1">
-        {[1, 2, 3, 4].map((i) => (
-          <StarSolid key={i} className="h-6 w-6 text-amber-400" />
-        ))}
-        <StarIcon className="h-6 w-6 text-gray-300" />
-      </div>
-      <p className="text-xs text-gray-500">4.0 / 5.0</p>
-    </KpiCard>
-  );
-}
+export default async function KpiCards() {
+  const kpisResult = await fetchDashboardKpis();
 
-function TeamPointsCard() {
-  return (
-    <KpiCard>
-      <div className="flex items-center gap-2">
-        <TrophyIcon className="h-5 w-5 text-amber-500" />
-        <span className="text-sm font-semibold text-gray-600">
-          Pontos do Time
-        </span>
-      </div>
-      <p className="text-3xl font-bold text-gray-900">3.650</p>
-    </KpiCard>
-  );
-}
+  const history = kpisResult.data?.closedHistory ?? [
+    { month: '-', count: 0 },
+    { month: '-', count: 0 },
+    { month: '-', count: 0 },
+  ];
+  const slaPercentage = kpisResult.data?.slaPercentage ?? 0;
+  const slaGoal = kpisResult.data?.slaGoal ?? 90;
 
-export default function KpiCards() {
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-      <ClosedCasesCard />
-      <SlaOnTimeCard />
-      <ClientSatisfactionCard />
-      <TeamPointsCard />
+    <div className="grid grid-cols-2 gap-4">
+      <ClosedCasesCard history={history} />
+      <SlaOnTimeCard slaPercentage={slaPercentage} slaGoal={slaGoal} />
     </div>
   );
 }

--- a/src/app/components/dashboards/performance-chart-lazy.tsx
+++ b/src/app/components/dashboards/performance-chart-lazy.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { PerformanceWeek } from '@/app/services/cases/fetch_performance_chart';
 import dynamic from 'next/dynamic';
 import { ChartSkeleton } from './skeletons';
 
@@ -7,6 +8,10 @@ const PerformanceChart = dynamic(() => import('./performance-chart'), {
   loading: () => <ChartSkeleton />,
 });
 
-export default function PerformanceChartLazy() {
-  return <PerformanceChart />;
+export default function PerformanceChartLazy({
+  data,
+}: {
+  data: PerformanceWeek[];
+}) {
+  return <PerformanceChart data={data} />;
 }

--- a/src/app/components/dashboards/performance-chart-server.tsx
+++ b/src/app/components/dashboards/performance-chart-server.tsx
@@ -2,7 +2,7 @@ import {
   fetchPerformanceData,
   PerformanceWeek,
 } from '@/app/services/cases/fetch_performance_chart';
-import PerformanceChart from './performance-chart';
+import PerformanceChartLazy from './performance-chart-lazy';
 
 const FALLBACK_DATA: PerformanceWeek[] = Array.from({ length: 6 }, (_, i) => ({
   week: `S${i + 1}`,
@@ -13,5 +13,5 @@ const FALLBACK_DATA: PerformanceWeek[] = Array.from({ length: 6 }, (_, i) => ({
 export default async function PerformanceChartServer() {
   const result = await fetchPerformanceData();
   const data = result.data ?? FALLBACK_DATA;
-  return <PerformanceChart data={data} />;
+  return <PerformanceChartLazy data={data} />;
 }

--- a/src/app/components/dashboards/performance-chart-server.tsx
+++ b/src/app/components/dashboards/performance-chart-server.tsx
@@ -1,0 +1,17 @@
+import {
+  fetchPerformanceData,
+  PerformanceWeek,
+} from '@/app/services/cases/fetch_performance_chart';
+import PerformanceChart from './performance-chart';
+
+const FALLBACK_DATA: PerformanceWeek[] = Array.from({ length: 6 }, (_, i) => ({
+  week: `S${i + 1}`,
+  tma: 0,
+  volume: 0,
+}));
+
+export default async function PerformanceChartServer() {
+  const result = await fetchPerformanceData();
+  const data = result.data ?? FALLBACK_DATA;
+  return <PerformanceChart data={data} />;
+}

--- a/src/app/components/dashboards/performance-chart.tsx
+++ b/src/app/components/dashboards/performance-chart.tsx
@@ -13,41 +13,40 @@ import {
 } from 'recharts';
 
 const data = [
-  { day: 'Seg', cases: 30, sla: 40, points: 20 },
-  { day: 'Seg', cases: 25, sla: 45, points: 22 },
-  { day: 'Ter', cases: 35, sla: 42, points: 28 },
-  { day: 'Qua', cases: 40, sla: 48, points: 35 },
-  { day: 'Qui', cases: 38, sla: 50, points: 40 },
-  { day: 'Sáb', cases: 45, sla: 47, points: 42 },
-  { day: 'Seg', cases: 50, sla: 52, points: 48 },
-  { day: 'Sáb', cases: 55, sla: 55, points: 55 },
+  { week: 'S1', tma: 4.2, volume: 38 },
+  { week: 'S2', tma: 3.8, volume: 42 },
+  { week: 'S3', tma: 5.1, volume: 55 },
+  { week: 'S4', tma: 4.6, volume: 50 },
+  { week: 'S5', tma: 3.5, volume: 44 },
+  { week: 'S6', tma: 3.2, volume: 47 },
 ];
 
 const LEGEND_LABELS: Record<string, string> = {
-  cases: 'Casos Finalizados',
-  sla: 'SLA no prazo',
-  points: 'Pontos do Time',
+  tma: 'TMA (dias)',
+  volume: 'Volume de Casos',
 };
 
 export default function PerformanceChart() {
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-gray-50 p-4 shadow-sm">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <ChartBarIcon className="h-5 w-5 text-blue-500" />
-          <span className="font-semibold text-gray-800">
-            Evolução de Desempenho
-          </span>
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-2">
+          <ChartBarIcon className="mt-0.5 h-5 w-5 shrink-0 text-blue-500" />
+          <div>
+            <span className="font-semibold text-gray-800">
+              Evolução de Desempenho (TMA)
+            </span>
+            <p className="text-xs text-gray-500">
+              Tempo Médio de Atendimento vs Volume Recebido
+            </p>
+          </div>
         </div>
-        <button className="flex items-center gap-1 text-sm text-blue-600 hover:underline">
-          Ver Histórico <span>›</span>
-        </button>
       </div>
 
       <ResponsiveContainer width="100%" height={200}>
         <LineChart
           data={data}
-          margin={{ top: 4, right: 8, left: -20, bottom: 0 }}
+          margin={{ top: 4, right: 16, left: -20, bottom: 0 }}
         >
           <CartesianGrid
             strokeDasharray="3 3"
@@ -55,13 +54,23 @@ export default function PerformanceChart() {
             stroke="#e5e7eb"
           />
           <XAxis
-            dataKey="day"
+            dataKey="week"
             tick={{ fontSize: 11, fill: '#9ca3af' }}
             axisLine={false}
             tickLine={false}
           />
           <YAxis
-            domain={[0, 60]}
+            yAxisId="tma"
+            orientation="left"
+            domain={[0, 8]}
+            tick={{ fontSize: 11, fill: '#9ca3af' }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            yAxisId="volume"
+            orientation="right"
+            domain={[0, 70]}
             tick={{ fontSize: 11, fill: '#9ca3af' }}
             axisLine={false}
             tickLine={false}
@@ -79,25 +88,19 @@ export default function PerformanceChart() {
             formatter={(value) => LEGEND_LABELS[value] ?? value}
           />
           <Line
+            yAxisId="tma"
             type="monotone"
-            dataKey="cases"
+            dataKey="tma"
             stroke="#3b82f6"
             strokeWidth={2}
             dot={{ r: 3 }}
             activeDot={{ r: 5 }}
           />
           <Line
+            yAxisId="volume"
             type="monotone"
-            dataKey="sla"
+            dataKey="volume"
             stroke="#f97316"
-            strokeWidth={2}
-            dot={{ r: 3 }}
-            activeDot={{ r: 5 }}
-          />
-          <Line
-            type="monotone"
-            dataKey="points"
-            stroke="#10b981"
             strokeWidth={2}
             dot={{ r: 3 }}
             activeDot={{ r: 5 }}

--- a/src/app/components/dashboards/performance-chart.tsx
+++ b/src/app/components/dashboards/performance-chart.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { PerformanceWeek } from '@/app/services/cases/fetch_performance_chart';
 import { ChartBarIcon } from '@heroicons/react/24/outline';
 import {
   CartesianGrid,
@@ -12,21 +13,16 @@ import {
   YAxis,
 } from 'recharts';
 
-const data = [
-  { week: 'S1', tma: 4.2, volume: 38 },
-  { week: 'S2', tma: 3.8, volume: 42 },
-  { week: 'S3', tma: 5.1, volume: 55 },
-  { week: 'S4', tma: 4.6, volume: 50 },
-  { week: 'S5', tma: 3.5, volume: 44 },
-  { week: 'S6', tma: 3.2, volume: 47 },
-];
-
 const LEGEND_LABELS: Record<string, string> = {
   tma: 'TMA (dias)',
   volume: 'Volume de Casos',
 };
 
-export default function PerformanceChart() {
+export default function PerformanceChart({
+  data,
+}: {
+  data: PerformanceWeek[];
+}) {
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-gray-50 p-4 shadow-sm">
       <div className="flex items-start justify-between">
@@ -62,7 +58,7 @@ export default function PerformanceChart() {
           <YAxis
             yAxisId="tma"
             orientation="left"
-            domain={[0, 8]}
+            domain={[0, 'auto']}
             tick={{ fontSize: 11, fill: '#9ca3af' }}
             axisLine={false}
             tickLine={false}
@@ -70,7 +66,7 @@ export default function PerformanceChart() {
           <YAxis
             yAxisId="volume"
             orientation="right"
-            domain={[0, 70]}
+            domain={[0, 'auto']}
             tick={{ fontSize: 11, fill: '#9ca3af' }}
             axisLine={false}
             tickLine={false}

--- a/src/app/components/dashboards/ranking.tsx
+++ b/src/app/components/dashboards/ranking.tsx
@@ -27,48 +27,102 @@ function getInitials(name: string): string {
 
 const MEDAL: Record<number, string> = { 0: '🥇', 1: '🥈', 2: '🥉' };
 
-const agents = [
+interface Agent {
+  name: string;
+  inProgress: {
+    green: number;
+    yellow: number;
+    red: number;
+    mostDelayed: string;
+  };
+  finalized: { vistoria: number; reparo: number };
+}
+
+const agents: Agent[] = [
   {
-    name: 'Daniel',
-    closed: [15, 7, 1] as [number, number, number],
-    visitRepair: [8, 17] as [number, number],
+    name: 'João Silva',
+    inProgress: { green: 8, yellow: 3, red: 2, mostDelayed: 'CASO-099' },
+    finalized: { vistoria: 20, reparo: 14 },
   },
   {
-    name: 'Maria',
-    closed: [15, 7, 1] as [number, number, number],
-    visitRepair: [8, 17] as [number, number],
+    name: 'Maria Oliveira',
+    inProgress: { green: 6, yellow: 4, red: 1, mostDelayed: 'CASO-074' },
+    finalized: { vistoria: 15, reparo: 13 },
   },
   {
-    name: 'João',
-    closed: [15, 7, 1] as [number, number, number],
-    visitRepair: [8, 17] as [number, number],
+    name: 'Daniel Costa',
+    inProgress: { green: 5, yellow: 2, red: 3, mostDelayed: 'CASO-051' },
+    finalized: { vistoria: 12, reparo: 9 },
   },
   {
-    name: 'Ana',
-    closed: [15, 7, 1] as [number, number, number],
-    visitRepair: [8, 17] as [number, number],
+    name: 'Ana Ferreira',
+    inProgress: { green: 4, yellow: 5, red: 0, mostDelayed: '' },
+    finalized: { vistoria: 10, reparo: 8 },
   },
 ];
 
-function SegmentedBar({
-  segments,
-  colors,
-}: {
-  segments: number[];
-  colors: string[];
-}) {
-  const total = segments.reduce((a, b) => a + b, 0);
+function DelayBar({ inProgress }: { inProgress: Agent['inProgress'] }) {
+  const total = inProgress.green + inProgress.yellow + inProgress.red;
+  if (total === 0)
+    return (
+      <div className="h-6 w-full rounded bg-gray-100 text-center text-xs leading-6 text-gray-400">
+        Sem casos em andamento
+      </div>
+    );
+
   return (
-    <div className="flex h-6 w-full overflow-hidden rounded">
-      {segments.map((val, i) => (
+    <div className="flex h-6 w-full overflow-hidden rounded text-xs font-bold text-white">
+      {inProgress.green > 0 && (
         <div
-          key={i}
-          className={`${colors[i]} flex items-center justify-center text-xs font-bold text-white`}
-          style={{ width: `${(val / total) * 100}%` }}
+          className="flex items-center justify-center bg-emerald-500"
+          style={{ width: `${(inProgress.green / total) * 100}%` }}
         >
-          {val}
+          {inProgress.green}
         </div>
-      ))}
+      )}
+      {inProgress.yellow > 0 && (
+        <div
+          className="flex items-center justify-center bg-amber-400"
+          style={{ width: `${(inProgress.yellow / total) * 100}%` }}
+        >
+          {inProgress.yellow}
+        </div>
+      )}
+      {inProgress.red > 0 && (
+        <div
+          className="flex items-center justify-center gap-1 bg-red-500"
+          style={{ width: `${(inProgress.red / total) * 100}%` }}
+        >
+          <span>{inProgress.red}</span>
+          {inProgress.mostDelayed && (
+            <span className="hidden truncate sm:inline">
+              #{inProgress.mostDelayed}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FinalizedBar({ finalized }: { finalized: Agent['finalized'] }) {
+  const total = finalized.vistoria + finalized.reparo;
+  if (total === 0) return null;
+
+  return (
+    <div className="flex h-6 w-full overflow-hidden rounded text-xs font-bold text-white">
+      <div
+        className="flex items-center justify-center bg-blue-500"
+        style={{ width: `${(finalized.vistoria / total) * 100}%` }}
+      >
+        {finalized.vistoria}
+      </div>
+      <div
+        className="flex items-center justify-center bg-violet-500"
+        style={{ width: `${(finalized.reparo / total) * 100}%` }}
+      >
+        {finalized.reparo}
+      </div>
     </div>
   );
 }
@@ -88,43 +142,91 @@ export default function Ranking() {
         </button>
       </div>
 
-      <div className="grid grid-cols-[auto_auto_1fr_1fr] items-center gap-x-3 gap-y-1 px-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
-        <span>#</span>
-        <span>Atendente</span>
-        <span>FINALIZADOS</span>
-        <span>VIST. / REPARO</span>
+      <div className="rounded-lg bg-gradient-to-r from-amber-400 to-orange-400 px-4 py-2 text-center text-sm font-bold text-white shadow-sm">
+        🏆 Bônus Liderança Geral: R$ 400,00
       </div>
 
-      {agents.map((agent, idx) => (
-        <div
-          key={agent.name}
-          className="grid grid-cols-[auto_auto_1fr_1fr] items-center gap-x-3"
-        >
-          <span className="w-8 text-center text-lg">
-            {MEDAL[idx] ?? (
-              <span className="text-sm font-semibold text-gray-500">
-                {idx + 1}
-              </span>
-            )}
-          </span>
-
-          <div
-            className={`h-8 w-8 rounded-full ${getAvatarColor(agent.name)} flex items-center justify-center text-xs font-bold text-white`}
-          >
-            {getInitials(agent.name)}
+      <div className="grid grid-cols-[16px_1fr] gap-x-3 gap-y-0.5 px-1 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+        <span>#</span>
+        <div className="grid grid-cols-[auto_1fr] gap-x-3">
+          <span className="w-20">Atendente</span>
+          <div className="grid grid-cols-2 gap-x-2">
+            <span>Em Andamento</span>
+            <span>Finalizados</span>
           </div>
-
-          <SegmentedBar
-            segments={agent.closed}
-            colors={['bg-emerald-500', 'bg-orange-400', 'bg-red-500']}
-          />
-
-          <SegmentedBar
-            segments={agent.visitRepair}
-            colors={['bg-cyan-500', 'bg-blue-500']}
-          />
         </div>
-      ))}
+      </div>
+
+      {agents.map((agent, idx) => {
+        const totalFinalized =
+          agent.finalized.vistoria + agent.finalized.reparo;
+        return (
+          <div
+            key={agent.name}
+            className="grid grid-cols-[16px_1fr] items-center gap-x-3"
+          >
+            <span className="text-center text-base leading-none">
+              {MEDAL[idx] ?? (
+                <span className="text-xs font-semibold text-gray-500">
+                  {idx + 1}
+                </span>
+              )}
+            </span>
+
+            <div className="grid grid-cols-[auto_1fr] items-center gap-x-3">
+              <div className="flex items-center gap-2">
+                <div
+                  className={`h-8 w-8 shrink-0 rounded-full ${getAvatarColor(agent.name)} flex items-center justify-center text-xs font-bold text-white`}
+                >
+                  {getInitials(agent.name)}
+                </div>
+                <div className="hidden min-w-[72px] sm:block">
+                  <p className="text-xs font-semibold leading-tight text-gray-800">
+                    {agent.name.split(' ')[0]}
+                  </p>
+                  <p className="text-[10px] text-gray-500">
+                    {totalFinalized} fin.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-2">
+                <div className="flex flex-col gap-0.5">
+                  <DelayBar inProgress={agent.inProgress} />
+                  <div className="flex gap-2 text-[9px] text-gray-400">
+                    <span className="flex items-center gap-0.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+                      ≤5d
+                    </span>
+                    <span className="flex items-center gap-0.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-amber-400" />
+                      5–10d
+                    </span>
+                    <span className="flex items-center gap-0.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-red-500" />
+                      &gt;10d
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-0.5">
+                  <FinalizedBar finalized={agent.finalized} />
+                  <div className="flex gap-2 text-[9px] text-gray-400">
+                    <span className="flex items-center gap-0.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-blue-500" />
+                      Vist.
+                    </span>
+                    <span className="flex items-center gap-0.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-violet-500" />
+                      Rep.
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/components/dashboards/ranking.tsx
+++ b/src/app/components/dashboards/ranking.tsx
@@ -1,3 +1,7 @@
+import {
+  fetchRankingData,
+  RankingAgent,
+} from '@/app/services/cases/fetch_ranking';
 import { TrophyIcon } from '@heroicons/react/24/outline';
 
 const AVATAR_COLORS = [
@@ -27,41 +31,7 @@ function getInitials(name: string): string {
 
 const MEDAL: Record<number, string> = { 0: '🥇', 1: '🥈', 2: '🥉' };
 
-interface Agent {
-  name: string;
-  inProgress: {
-    green: number;
-    yellow: number;
-    red: number;
-    mostDelayed: string;
-  };
-  finalized: { vistoria: number; reparo: number };
-}
-
-const agents: Agent[] = [
-  {
-    name: 'João Silva',
-    inProgress: { green: 8, yellow: 3, red: 2, mostDelayed: 'CASO-099' },
-    finalized: { vistoria: 20, reparo: 14 },
-  },
-  {
-    name: 'Maria Oliveira',
-    inProgress: { green: 6, yellow: 4, red: 1, mostDelayed: 'CASO-074' },
-    finalized: { vistoria: 15, reparo: 13 },
-  },
-  {
-    name: 'Daniel Costa',
-    inProgress: { green: 5, yellow: 2, red: 3, mostDelayed: 'CASO-051' },
-    finalized: { vistoria: 12, reparo: 9 },
-  },
-  {
-    name: 'Ana Ferreira',
-    inProgress: { green: 4, yellow: 5, red: 0, mostDelayed: '' },
-    finalized: { vistoria: 10, reparo: 8 },
-  },
-];
-
-function DelayBar({ inProgress }: { inProgress: Agent['inProgress'] }) {
+function DelayBar({ inProgress }: { inProgress: RankingAgent['inProgress'] }) {
   const total = inProgress.green + inProgress.yellow + inProgress.red;
   if (total === 0)
     return (
@@ -105,7 +75,7 @@ function DelayBar({ inProgress }: { inProgress: Agent['inProgress'] }) {
   );
 }
 
-function FinalizedBar({ finalized }: { finalized: Agent['finalized'] }) {
+function FinalizedBar({ finalized }: { finalized: RankingAgent['finalized'] }) {
   const total = finalized.vistoria + finalized.reparo;
   if (total === 0) return null;
 
@@ -127,7 +97,10 @@ function FinalizedBar({ finalized }: { finalized: Agent['finalized'] }) {
   );
 }
 
-export default function Ranking() {
+export default async function Ranking() {
+  const result = await fetchRankingData();
+  const agents = result.data ?? [];
+
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-gray-50 p-4 shadow-sm">
       <div className="flex items-center justify-between">

--- a/src/app/components/dashboards/skeletons.tsx
+++ b/src/app/components/dashboards/skeletons.tsx
@@ -4,7 +4,7 @@ const shimmer =
 export function KpiCardsSkeleton() {
   return (
     <>
-      {[...Array(4)].map((_, i) => (
+      {[...Array(2)].map((_, i) => (
         <div
           key={i}
           className={`${shimmer} relative overflow-hidden rounded-xl bg-gray-100 p-4 shadow-sm`}
@@ -13,8 +13,21 @@ export function KpiCardsSkeleton() {
             <div className="h-5 w-5 rounded-md bg-gray-200" />
             <div className="h-4 w-32 rounded-md bg-gray-200" />
           </div>
-          <div className="mb-2 h-8 w-20 rounded-md bg-gray-200" />
-          <div className="h-3 w-24 rounded-md bg-gray-200" />
+          <div className="flex items-end justify-between">
+            <div>
+              <div className="mb-2 h-8 w-20 rounded-md bg-gray-200" />
+              <div className="h-3 w-28 rounded-md bg-gray-200" />
+            </div>
+            <div className="flex items-end gap-1.5">
+              {[...Array(3)].map((_, j) => (
+                <div
+                  key={j}
+                  className="w-6 rounded-t bg-gray-200"
+                  style={{ height: `${16 + j * 8}px` }}
+                />
+              ))}
+            </div>
+          </div>
         </div>
       ))}
     </>
@@ -26,13 +39,27 @@ export function RankingSkeleton() {
     <div
       className={`${shimmer} relative overflow-hidden rounded-xl bg-gray-100 p-4 shadow-sm`}
     >
-      <div className="mb-4 h-5 w-40 rounded-md bg-gray-200" />
+      <div className="mb-3 flex items-center justify-between">
+        <div className="h-5 w-40 rounded-md bg-gray-200" />
+        <div className="h-4 w-16 rounded-md bg-gray-200" />
+      </div>
+      <div className="mb-3 h-9 w-full rounded-lg bg-gray-200" />
       {[...Array(4)].map((_, i) => (
-        <div key={i} className="mb-4 flex items-center gap-3">
-          <div className="h-6 w-6 rounded-full bg-gray-200" />
-          <div className="h-8 w-8 rounded-full bg-gray-200" />
-          <div className="h-4 w-20 rounded-md bg-gray-200" />
-          <div className="h-6 flex-1 rounded-md bg-gray-200" />
+        <div key={i} className="mb-4 grid grid-cols-[16px_1fr] gap-x-3">
+          <div className="h-4 w-4 rounded-full bg-gray-200" />
+          <div className="grid grid-cols-[auto_1fr] gap-x-3">
+            <div className="flex items-center gap-2">
+              <div className="h-8 w-8 rounded-full bg-gray-200" />
+              <div className="hidden sm:block">
+                <div className="mb-1 h-3 w-16 rounded bg-gray-200" />
+                <div className="h-2 w-10 rounded bg-gray-200" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-x-2">
+              <div className="h-6 rounded bg-gray-200" />
+              <div className="h-6 rounded bg-gray-200" />
+            </div>
+          </div>
         </div>
       ))}
     </div>
@@ -44,13 +71,36 @@ export function ChartSkeleton() {
     <div
       className={`${shimmer} relative overflow-hidden rounded-xl bg-gray-100 p-4 shadow-sm`}
     >
-      <div className="mb-4 h-5 w-48 rounded-md bg-gray-200" />
+      <div className="mb-1 h-5 w-56 rounded-md bg-gray-200" />
+      <div className="mb-4 h-3 w-48 rounded-md bg-gray-200" />
       <div className="h-48 w-full rounded-md bg-gray-200" />
       <div className="mt-3 flex gap-4">
-        {[...Array(3)].map((_, i) => (
+        {[...Array(2)].map((_, i) => (
           <div key={i} className="flex items-center gap-1">
             <div className="h-3 w-3 rounded-full bg-gray-200" />
             <div className="h-3 w-20 rounded-md bg-gray-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AttendanceBonusSkeleton() {
+  return (
+    <div
+      className={`${shimmer} relative overflow-hidden rounded-xl bg-gray-100 p-4 shadow-sm`}
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="h-5 w-36 rounded-md bg-gray-200" />
+        <div className="h-5 w-20 rounded-full bg-gray-200" />
+      </div>
+      <div className="mb-3 h-3 w-24 rounded-md bg-gray-200" />
+      <div className="grid grid-cols-4 gap-3">
+        {[...Array(12)].map((_, i) => (
+          <div key={i} className="flex flex-col items-center gap-1">
+            <div className="h-12 w-12 rounded-full bg-gray-200" />
+            <div className="h-2 w-10 rounded bg-gray-200" />
           </div>
         ))}
       </div>

--- a/src/app/components/panel/__fixtures__/builders.ts
+++ b/src/app/components/panel/__fixtures__/builders.ts
@@ -1,6 +1,7 @@
 import { CaseFull, CaseStatus } from '@/app/types/case';
 import { Contractor } from '@/app/types/contractor';
 import { Customer } from '@/app/types/customer';
+import { PanelCaseItem } from '@/app/types/panel-case-item';
 import { Partner } from '@/app/types/partner';
 import { SearchResponse } from '@/app/types/search_response';
 
@@ -85,6 +86,25 @@ export function buildCaseFull(overrides: Partial<CaseFull> = {}): CaseFull {
     customer: buildCustomer(),
     contractor: buildContractor(),
     partner: buildPartner(),
+    transactions: [],
+    ...overrides,
+  };
+}
+
+export function buildPanelCaseItem(
+  overrides: Partial<PanelCaseItem> = {}
+): PanelCaseItem {
+  return {
+    case_id: 'case-001',
+    created_at: '2024-03-15T10:00:00Z',
+    type: 'repair',
+    external_reference: 'SIN-001',
+    customer_document: '111.222.333-44',
+    customer_first_name: 'Maria',
+    customer_last_name: 'Santos',
+    customer_city: 'São Paulo',
+    partner_first_name: 'João',
+    contractor_company_name: 'Seguradora ABC',
     transactions: [],
     ...overrides,
   };

--- a/src/app/components/panel/__tests__/table.test.tsx
+++ b/src/app/components/panel/__tests__/table.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import ControlPanelTable from '../table';
 import {
-  buildCaseFull,
-  buildCustomer,
+  buildPanelCaseItem,
   buildSearchResponse,
 } from '../__fixtures__/builders';
 
@@ -21,13 +20,10 @@ beforeEach(() => {
 describe('ControlPanelTable', () => {
   describe('rendering', () => {
     it('should render all column headers', () => {
-      // Arrange
       const cases = buildSearchResponse([]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       expect(screen.getByText('Data')).toBeInTheDocument();
       expect(screen.getByText('Cidade')).toBeInTheDocument();
       expect(screen.getByText('Segurado')).toBeInTheDocument();
@@ -37,93 +33,77 @@ describe('ControlPanelTable', () => {
     });
 
     it('should render the segurado full name from customer', () => {
-      // Arrange
-      const crmCase = buildCaseFull({
-        customer: buildCustomer({ first_name: 'Ana', last_name: 'Pereira' }),
+      const crmCase = buildPanelCaseItem({
+        customer_first_name: 'Ana',
+        customer_last_name: 'Pereira',
       });
       const cases = buildSearchResponse([crmCase]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       expect(screen.getByText('Ana Pereira')).toBeInTheDocument();
     });
 
     it('should show a dash when case has no customer', () => {
-      // Arrange
-      const crmCase = buildCaseFull({ customer: undefined });
+      const crmCase = buildPanelCaseItem({
+        customer_first_name: undefined,
+        customer_last_name: undefined,
+      });
       const cases = buildSearchResponse([crmCase]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       expect(screen.getAllByText('-').length).toBeGreaterThan(0);
     });
 
     it('should render partner first name in Técnico column', () => {
-      // Arrange
-      const crmCase = buildCaseFull();
+      const crmCase = buildPanelCaseItem({ partner_first_name: 'João' });
       const cases = buildSearchResponse([crmCase]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       expect(screen.getByText('João')).toBeInTheDocument();
     });
 
     it('should render external reference in Senha column', () => {
-      // Arrange
-      const crmCase = buildCaseFull({ external_reference: 'SIN-999' });
+      const crmCase = buildPanelCaseItem({ external_reference: 'SIN-999' });
       const cases = buildSearchResponse([crmCase]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       expect(screen.getByText('SIN-999')).toBeInTheDocument();
     });
 
     it('should render contractor company name in Seguradora column', () => {
-      // Arrange
-      const crmCase = buildCaseFull();
+      const crmCase = buildPanelCaseItem({
+        contractor_company_name: 'Seguradora ABC',
+      });
       const cases = buildSearchResponse([crmCase]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       expect(screen.getByText('Seguradora ABC')).toBeInTheDocument();
     });
   });
 
   describe('duplicate document highlighting', () => {
     it('should not apply red color when all documents are unique', () => {
-      // Arrange
-      const case1 = buildCaseFull({
+      const case1 = buildPanelCaseItem({
         case_id: 'case-001',
-        customer: buildCustomer({
-          document: '111.111.111-11',
-          first_name: 'Ana',
-          last_name: 'Lima',
-        }),
+        customer_document: '111.111.111-11',
+        customer_first_name: 'Ana',
+        customer_last_name: 'Lima',
       });
-      const case2 = buildCaseFull({
+      const case2 = buildPanelCaseItem({
         case_id: 'case-002',
-        customer: buildCustomer({
-          document: '222.222.222-22',
-          first_name: 'Pedro',
-          last_name: 'Costa',
-        }),
+        customer_document: '222.222.222-22',
+        customer_first_name: 'Pedro',
+        customer_last_name: 'Costa',
       });
       const cases = buildSearchResponse([case1, case2]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       const anaCell = screen.getByText('Ana Lima').closest('td');
       const pedroCell = screen.getByText('Pedro Costa').closest('td');
       expect(anaCell?.className).not.toContain('text-red-500');
@@ -131,30 +111,23 @@ describe('ControlPanelTable', () => {
     });
 
     it('should apply red color to segurado names when the same document appears more than once', () => {
-      // Arrange
       const sharedDocument = '111.111.111-11';
-      const case1 = buildCaseFull({
+      const case1 = buildPanelCaseItem({
         case_id: 'case-001',
-        customer: buildCustomer({
-          document: sharedDocument,
-          first_name: 'Maria',
-          last_name: 'Santos',
-        }),
+        customer_document: sharedDocument,
+        customer_first_name: 'Maria',
+        customer_last_name: 'Santos',
       });
-      const case2 = buildCaseFull({
+      const case2 = buildPanelCaseItem({
         case_id: 'case-002',
-        customer: buildCustomer({
-          document: sharedDocument,
-          first_name: 'Maria',
-          last_name: 'Santos',
-        }),
+        customer_document: sharedDocument,
+        customer_first_name: 'Maria',
+        customer_last_name: 'Santos',
       });
       const cases = buildSearchResponse([case1, case2]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       const nameCells = screen
         .getAllByText('Maria Santos')
         .map((el) => el.closest('td'));
@@ -164,38 +137,29 @@ describe('ControlPanelTable', () => {
     });
 
     it('should only color the duplicate entries red, not unique ones', () => {
-      // Arrange
       const sharedDocument = '111.111.111-11';
-      const case1 = buildCaseFull({
+      const case1 = buildPanelCaseItem({
         case_id: 'case-001',
-        customer: buildCustomer({
-          document: sharedDocument,
-          first_name: 'Maria',
-          last_name: 'Santos',
-        }),
+        customer_document: sharedDocument,
+        customer_first_name: 'Maria',
+        customer_last_name: 'Santos',
       });
-      const case2 = buildCaseFull({
+      const case2 = buildPanelCaseItem({
         case_id: 'case-002',
-        customer: buildCustomer({
-          document: sharedDocument,
-          first_name: 'Maria',
-          last_name: 'Santos',
-        }),
+        customer_document: sharedDocument,
+        customer_first_name: 'Maria',
+        customer_last_name: 'Santos',
       });
-      const case3 = buildCaseFull({
+      const case3 = buildPanelCaseItem({
         case_id: 'case-003',
-        customer: buildCustomer({
-          document: '999.999.999-99',
-          first_name: 'Pedro',
-          last_name: 'Alves',
-        }),
+        customer_document: '999.999.999-99',
+        customer_first_name: 'Pedro',
+        customer_last_name: 'Alves',
       });
       const cases = buildSearchResponse([case1, case2, case3]);
 
-      // Act
       render(<ControlPanelTable cases={cases} />);
 
-      // Assert
       const pedroCell = screen.getByText('Pedro Alves').closest('td');
       expect(pedroCell?.className).not.toContain('text-red-500');
     });

--- a/src/app/components/tv/auto-refresh.tsx
+++ b/src/app/components/tv/auto-refresh.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const REFRESH_MS = Number(process.env.NEXT_PUBLIC_TV_REFRESH_MS ?? 120_000);
+
+export default function AutoRefresh() {
+  const router = useRouter();
+  const [remaining, setRemaining] = useState(REFRESH_MS);
+
+  useEffect(() => {
+    const tick = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1000) {
+          router.refresh();
+          return REFRESH_MS;
+        }
+        return prev - 1000;
+      });
+    }, 1000);
+    return () => clearInterval(tick);
+  }, [router]);
+
+  const minutes = Math.floor(remaining / 60_000);
+  const seconds = Math.floor((remaining % 60_000) / 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+
+  return (
+    <span className="flex items-center gap-1 text-xs tabular-nums text-gray-400">
+      <svg
+        className="h-3 w-3 animate-spin"
+        style={{ animationDuration: `${REFRESH_MS}ms` }}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+      </svg>
+      {pad(minutes)}:{pad(seconds)}
+    </span>
+  );
+}

--- a/src/app/services/cases/fetch_dashboard_kpis.ts
+++ b/src/app/services/cases/fetch_dashboard_kpis.ts
@@ -1,0 +1,132 @@
+'use server';
+import { getApiErrorMessage } from '@/app/libs/api-error';
+import { Case } from '@/app/types/case';
+import { SearchResponse } from '@/app/types/search_response';
+import { ServiceResponse } from '@/app/types/service';
+import { cookies } from 'next/headers';
+import { crmCoreApiKey, crmCoreEndpoint } from '.';
+
+export interface MonthlyClosedCount {
+  month: string;
+  count: number;
+}
+
+export interface DashboardKpis {
+  closedHistory: MonthlyClosedCount[];
+  slaPercentage: number;
+  slaGoal: number;
+}
+
+function getMonthDateRange(
+  year: number,
+  month: number
+): { start: string; end: string; label: string } {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const start = `${year}-${pad(month + 1)}-01`;
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  const end = `${year}-${pad(month + 1)}-${pad(lastDay)}`;
+  const label = new Date(year, month, 1)
+    .toLocaleString('pt-BR', { month: 'short' })
+    .replace('.', '')
+    .replace(/^\w/, (c) => c.toUpperCase());
+  return { start, end, label };
+}
+
+async function buildHeaders(jwt: string | undefined): Promise<HeadersInit> {
+  return {
+    'Content-Type': 'application/json',
+    'X-API-Key': crmCoreApiKey || '',
+    Authorization: `Bearer ${jwt}`,
+  };
+}
+
+async function fetchClosedCount(
+  start: string,
+  end: string,
+  headers: HeadersInit
+): Promise<number> {
+  const url = `${crmCoreEndpoint}/crm/core/api/v1/cases?status=Closed&closed_at_start=${start}&closed_at_end=${end}&limit=1&offset=0`;
+  const resp = await fetch(url, { method: 'GET', headers });
+  if (!resp.ok) return 0;
+  const data = (await resp.json()) as SearchResponse<Case>;
+  return data.paging.total;
+}
+
+async function fetchAllClosedInPeriod(
+  start: string,
+  end: string,
+  headers: HeadersInit
+): Promise<Case[]> {
+  const limit = 500;
+  let offset = 0;
+  const result: Case[] = [];
+
+  while (true) {
+    const url = `${crmCoreEndpoint}/crm/core/api/v1/cases?status=Closed&closed_at_start=${start}&closed_at_end=${end}&limit=${limit}&offset=${offset}`;
+    const resp = await fetch(url, { method: 'GET', headers });
+    if (!resp.ok) break;
+
+    const data = (await resp.json()) as SearchResponse<Case>;
+    result.push(...data.result);
+
+    if (offset + limit >= data.paging.total) break;
+    offset += limit;
+  }
+
+  return result;
+}
+
+export async function fetchDashboardKpis(): Promise<
+  ServiceResponse<DashboardKpis>
+> {
+  try {
+    const jwt = (await cookies()).get('jwt')?.value;
+    const headers = await buildHeaders(jwt);
+
+    const now = new Date();
+    const months = [
+      getMonthDateRange(now.getFullYear(), now.getMonth() - 2),
+      getMonthDateRange(now.getFullYear(), now.getMonth() - 1),
+      getMonthDateRange(now.getFullYear(), now.getMonth()),
+    ];
+
+    const currentMonth = months[months.length - 1];
+
+    const [countResults, currentMonthCases] = await Promise.all([
+      Promise.all(months.map((m) => fetchClosedCount(m.start, m.end, headers))),
+      fetchAllClosedInPeriod(currentMonth.start, currentMonth.end, headers),
+    ]);
+
+    const closedHistory: MonthlyClosedCount[] = months.map((m, i) => ({
+      month: m.label,
+      count: countResults[i],
+    }));
+
+    const casesWithDates = currentMonthCases.filter(
+      (c) => c.target_date && c.closed_at
+    );
+    const slaCompliant = casesWithDates.filter(
+      (c) => new Date(c.closed_at!) <= new Date(c.target_date!)
+    );
+    const slaPercentage =
+      casesWithDates.length > 0
+        ? Math.round((slaCompliant.length / casesWithDates.length) * 1000) / 10
+        : 0;
+
+    return {
+      success: true,
+      message: '',
+      data: {
+        closedHistory,
+        slaPercentage,
+        slaGoal: 90,
+      },
+    };
+  } catch (ex) {
+    console.error(ex);
+    return {
+      success: false,
+      message: 'algo de errado aconteceu, contate o suporte!',
+    };
+  }
+}

--- a/src/app/services/cases/fetch_performance_chart.ts
+++ b/src/app/services/cases/fetch_performance_chart.ts
@@ -1,0 +1,129 @@
+'use server';
+import { Case } from '@/app/types/case';
+import { SearchResponse } from '@/app/types/search_response';
+import { ServiceResponse } from '@/app/types/service';
+import { cookies } from 'next/headers';
+import { crmCoreApiKey, crmCoreEndpoint } from '.';
+
+export interface PerformanceWeek {
+  week: string;
+  tma: number;
+  volume: number;
+}
+
+function formatDate(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function buildWeekBuckets(numWeeks = 6) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayOfWeek = today.getDay();
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  const currentMonday = new Date(today);
+  currentMonday.setDate(today.getDate() - daysToMonday);
+
+  const buckets = [];
+  for (let i = numWeeks - 1; i >= 0; i--) {
+    const weekStart = new Date(currentMonday);
+    weekStart.setDate(currentMonday.getDate() - i * 7);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+    weekEnd.setHours(23, 59, 59, 999);
+
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const label = `${pad(weekStart.getDate())}/${pad(weekStart.getMonth() + 1)}`;
+    buckets.push({ start: weekStart, end: weekEnd, label });
+  }
+
+  return buckets;
+}
+
+async function fetchAllPages<T>(
+  buildUrl: (limit: number, offset: number) => string,
+  headers: HeadersInit
+): Promise<T[]> {
+  const limit = 500;
+  let offset = 0;
+  const result: T[] = [];
+
+  while (true) {
+    const resp = await fetch(buildUrl(limit, offset), {
+      method: 'GET',
+      headers,
+    });
+    if (!resp.ok) break;
+    const data = (await resp.json()) as SearchResponse<T>;
+    result.push(...data.result);
+    if (offset + limit >= data.paging.total) break;
+    offset += limit;
+  }
+
+  return result;
+}
+
+export async function fetchPerformanceData(): Promise<
+  ServiceResponse<PerformanceWeek[]>
+> {
+  try {
+    const jwt = (await cookies()).get('jwt')?.value;
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      'X-API-Key': crmCoreApiKey || '',
+      Authorization: `Bearer ${jwt}`,
+    };
+
+    const buckets = buildWeekBuckets(6);
+    const startDate = formatDate(buckets[0].start);
+    const endDate = formatDate(buckets[buckets.length - 1].end);
+
+    const base = `${crmCoreEndpoint}/crm/core/api/v1`;
+    const closedCases = await fetchAllPages<Case>(
+      (limit, offset) =>
+        `${base}/cases?status=Closed&closed_at_start=${startDate}&closed_at_end=${endDate}&limit=${limit}&offset=${offset}`,
+      headers
+    );
+
+    const weekData = buckets.map((bucket) => ({
+      week: bucket.label,
+      tmas: [] as number[],
+      count: 0,
+    }));
+
+    for (const c of closedCases) {
+      if (!c.closed_at) continue;
+      const closedDate = new Date(c.closed_at);
+
+      const bucketIdx = buckets.findIndex(
+        (b) => closedDate >= b.start && closedDate <= b.end
+      );
+      if (bucketIdx === -1) continue;
+
+      weekData[bucketIdx].count++;
+      const createdDate = new Date(c.created_at);
+      const days = (closedDate.getTime() - createdDate.getTime()) / 86_400_000;
+      weekData[bucketIdx].tmas.push(days);
+    }
+
+    const data: PerformanceWeek[] = weekData.map((w) => ({
+      week: w.week,
+      tma:
+        w.tmas.length > 0
+          ? Math.round(
+              (w.tmas.reduce((a, b) => a + b, 0) / w.tmas.length) * 10
+            ) / 10
+          : 0,
+      volume: w.count,
+    }));
+
+    return { success: true, message: '', data };
+  } catch (ex) {
+    console.error(ex);
+    return {
+      success: false,
+      message: 'algo de errado aconteceu, contate o suporte!',
+    };
+  }
+}

--- a/src/app/services/cases/fetch_ranking.ts
+++ b/src/app/services/cases/fetch_ranking.ts
@@ -1,0 +1,196 @@
+'use server';
+import { Case, CaseStatus } from '@/app/types/case';
+import { SearchResponse } from '@/app/types/search_response';
+import { ServiceResponse } from '@/app/types/service';
+import { User } from '@/app/types/user';
+import { cookies } from 'next/headers';
+import { crmCoreApiKey, crmCoreEndpoint } from '.';
+
+const IN_PROGRESS_STATUSES = [
+  CaseStatus.NEW,
+  CaseStatus.CUSTOMER_INFO,
+  CaseStatus.WAITING_PARTNER,
+  CaseStatus.ONGOING,
+  CaseStatus.REPORT,
+  CaseStatus.PAYMENT,
+  CaseStatus.RECEIPT,
+];
+
+export interface RankingAgent {
+  name: string;
+  inProgress: {
+    green: number;
+    yellow: number;
+    red: number;
+    mostDelayed: string;
+  };
+  finalized: {
+    vistoria: number;
+    reparo: number;
+  };
+}
+
+function daysSince(dateStr: string): number {
+  return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86_400_000);
+}
+
+function currentMonthRange(): { start: string; end: string } {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const start = `${year}-${pad(month + 1)}-01`;
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  const end = `${year}-${pad(month + 1)}-${pad(lastDay)}`;
+  return { start, end };
+}
+
+async function fetchAllPages<T>(
+  buildUrl: (limit: number, offset: number) => string,
+  headers: HeadersInit
+): Promise<T[]> {
+  const limit = 500;
+  let offset = 0;
+  const result: T[] = [];
+
+  while (true) {
+    const resp = await fetch(buildUrl(limit, offset), {
+      method: 'GET',
+      headers,
+    });
+    if (!resp.ok) break;
+    const data = (await resp.json()) as SearchResponse<T>;
+    result.push(...data.result);
+    if (offset + limit >= data.paging.total) break;
+    offset += limit;
+  }
+
+  return result;
+}
+
+export async function fetchRankingData(): Promise<
+  ServiceResponse<RankingAgent[]>
+> {
+  try {
+    const jwt = (await cookies()).get('jwt')?.value;
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      'X-API-Key': crmCoreApiKey || '',
+      Authorization: `Bearer ${jwt}`,
+    };
+
+    const base = `${crmCoreEndpoint}/crm/core/api/v1`;
+    const { start, end } = currentMonthRange();
+    const inProgressQuery = IN_PROGRESS_STATUSES.map((s) => `status=${s}`).join(
+      '&'
+    );
+
+    const [inProgressCases, closedCases] = await Promise.all([
+      fetchAllPages<Case>(
+        (limit, offset) =>
+          `${base}/cases?${inProgressQuery}&limit=${limit}&offset=${offset}`,
+        headers
+      ),
+      fetchAllPages<Case>(
+        (limit, offset) =>
+          `${base}/cases?status=Closed&closed_at_start=${start}&closed_at_end=${end}&limit=${limit}&offset=${offset}`,
+        headers
+      ),
+    ]);
+
+    const ownerIds = [
+      ...new Set(
+        [...inProgressCases, ...closedCases]
+          .map((c) => c.owner_id)
+          .filter((id): id is string => Boolean(id))
+      ),
+    ];
+
+    const usersMap = new Map<string, User>();
+    if (ownerIds.length > 0) {
+      const userQuery = ownerIds.map((id) => `user_id=${id}`).join('&');
+      const resp = await fetch(
+        `${base}/users?${userQuery}&limit=${ownerIds.length + 10}`,
+        { method: 'GET', headers }
+      );
+      if (resp.ok) {
+        const data = (await resp.json()) as SearchResponse<User>;
+        data.result.forEach((u) => usersMap.set(u.user_id, u));
+      }
+    }
+
+    const rankingMap = new Map<string, RankingAgent>();
+    const oldestRedCase = new Map<string, { date: Date; ref: string }>();
+
+    const getOrCreate = (ownerId: string): RankingAgent => {
+      if (!rankingMap.has(ownerId)) {
+        const user = usersMap.get(ownerId);
+        const name = user
+          ? `${user.first_name} ${user.last_name}`.trim()
+          : ownerId.slice(0, 8);
+        rankingMap.set(ownerId, {
+          name,
+          inProgress: { green: 0, yellow: 0, red: 0, mostDelayed: '' },
+          finalized: { vistoria: 0, reparo: 0 },
+        });
+      }
+      return rankingMap.get(ownerId)!;
+    };
+
+    for (const c of inProgressCases) {
+      if (!c.owner_id) continue;
+      const agent = getOrCreate(c.owner_id);
+      const days = daysSince(c.created_at);
+
+      if (days <= 5) {
+        agent.inProgress.green++;
+      } else if (days <= 10) {
+        agent.inProgress.yellow++;
+      } else {
+        agent.inProgress.red++;
+        const caseDate = new Date(c.created_at);
+        const current = oldestRedCase.get(c.owner_id);
+        if (!current || caseDate < current.date) {
+          oldestRedCase.set(c.owner_id, {
+            date: caseDate,
+            ref: c.external_reference || c.case_id.slice(0, 8),
+          });
+        }
+      }
+    }
+
+    for (const [ownerId, oldest] of oldestRedCase) {
+      const agent = rankingMap.get(ownerId);
+      if (agent) agent.inProgress.mostDelayed = oldest.ref;
+    }
+
+    for (const c of closedCases) {
+      if (!c.owner_id) continue;
+      const agent = getOrCreate(c.owner_id);
+      if (c.type === 'inspection') {
+        agent.finalized.vistoria++;
+      } else if (c.type === 'repair') {
+        agent.finalized.reparo++;
+      }
+    }
+
+    const agents = [...rankingMap.values()].sort((a, b) => {
+      const aFin = a.finalized.vistoria + a.finalized.reparo;
+      const bFin = b.finalized.vistoria + b.finalized.reparo;
+      if (bFin !== aFin) return bFin - aFin;
+      const aInProg =
+        a.inProgress.green + a.inProgress.yellow + a.inProgress.red;
+      const bInProg =
+        b.inProgress.green + b.inProgress.yellow + b.inProgress.red;
+      return bInProg - aInProg;
+    });
+
+    return { success: true, message: '', data: agents };
+  } catch (ex) {
+    console.error(ex);
+    return {
+      success: false,
+      message: 'algo de errado aconteceu, contate o suporte!',
+    };
+  }
+}

--- a/src/app/services/cases/index.ts
+++ b/src/app/services/cases/index.ts
@@ -3,6 +3,7 @@ import { changePartner } from './change_partner';
 import { changeStatus } from './change_status';
 import { createCaseBatch } from './create_batch';
 import { createCase } from './create_case';
+import { fetchDashboardKpis } from './fetch_dashboard_kpis';
 import { getCaseByID } from './get_by_id';
 import { getCaseFullByID } from './get_full_by_id';
 import { publishCase } from './publish_case';
@@ -19,6 +20,7 @@ export {
   changeStatus,
   createCase,
   fetchCases,
+  fetchDashboardKpis,
   getCaseByID,
   createCaseBatch,
   publishCase,

--- a/src/app/services/cases/index.ts
+++ b/src/app/services/cases/index.ts
@@ -4,6 +4,8 @@ import { changeStatus } from './change_status';
 import { createCaseBatch } from './create_batch';
 import { createCase } from './create_case';
 import { fetchDashboardKpis } from './fetch_dashboard_kpis';
+import { fetchPerformanceData } from './fetch_performance_chart';
+import { fetchRankingData } from './fetch_ranking';
 import { getCaseByID } from './get_by_id';
 import { getCaseFullByID } from './get_full_by_id';
 import { publishCase } from './publish_case';
@@ -21,6 +23,8 @@ export {
   createCase,
   fetchCases,
   fetchDashboardKpis,
+  fetchPerformanceData,
+  fetchRankingData,
   getCaseByID,
   createCaseBatch,
   publishCase,

--- a/src/app/services/users/fetch_operators.ts
+++ b/src/app/services/users/fetch_operators.ts
@@ -1,0 +1,42 @@
+'use server';
+import { SearchResponse } from '@/app/types/search_response';
+import { ServiceResponse } from '@/app/types/service';
+import { User, UserRole } from '@/app/types/user';
+import { cookies } from 'next/headers';
+import { crmCoreEndpoint } from '../cases';
+
+export async function fetchOperators(): Promise<ServiceResponse<User[]>> {
+  try {
+    const jwt = (await cookies()).get('jwt')?.value;
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      'X-API-Key': process.env.CRM_CORE_API_KEY || '',
+      Authorization: `Bearer ${jwt}`,
+    };
+
+    const base = `${crmCoreEndpoint}/crm/core/api/v1`;
+    const limit = 500;
+    let offset = 0;
+    const result: User[] = [];
+
+    while (true) {
+      const resp = await fetch(
+        `${base}/users?role=${UserRole.OPERATOR}&active=true&limit=${limit}&offset=${offset}`,
+        { method: 'GET', headers }
+      );
+      if (!resp.ok) break;
+      const data = (await resp.json()) as SearchResponse<User>;
+      result.push(...data.result);
+      if (offset + limit >= data.paging.total) break;
+      offset += limit;
+    }
+
+    return { success: true, message: '', data: result };
+  } catch (ex) {
+    console.error(ex);
+    return {
+      success: false,
+      message: 'algo de errado aconteceu, contate o suporte!',
+    };
+  }
+}

--- a/src/app/tv/dashboards/__tests__/page.test.tsx
+++ b/src/app/tv/dashboards/__tests__/page.test.tsx
@@ -41,18 +41,23 @@ jest.mock('../../../components/dashboards/skeletons', () => ({
   ),
 }));
 
+jest.mock('../../../components/tv/auto-refresh', () => ({
+  __esModule: true,
+  default: () => <div data-testid="auto-refresh" />,
+}));
+
 jest.mock('@heroicons/react/24/outline', () => ({
   TrophyIcon: () => <svg data-testid="trophy-icon" />,
 }));
 
 const { getCurrentUser } = jest.requireMock('../../../libs/session');
-const mockUser = { id: 'user-1', role: 'admin', name: 'Test User' };
+const mockAdminUser = { id: 'user-1', role: 'admin', name: 'Test User' };
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('Page', () => {
+describe('TvDashboardPage', () => {
   describe('authentication', () => {
     it('should redirect to /login when user is not authenticated', async () => {
       getCurrentUser.mockResolvedValue(null);
@@ -60,8 +65,14 @@ describe('Page', () => {
       expect(redirect).toHaveBeenCalledWith('/login');
     });
 
-    it('should not redirect when user is authenticated', async () => {
-      getCurrentUser.mockResolvedValue(mockUser);
+    it('should redirect to /home when user lacks admin role', async () => {
+      getCurrentUser.mockResolvedValue({ id: 'user-2', role: 'operator' });
+      await expect(Page()).rejects.toThrow('NEXT_REDIRECT:/home');
+      expect(redirect).toHaveBeenCalledWith('/home');
+    });
+
+    it('should not redirect when user has admin role', async () => {
+      getCurrentUser.mockResolvedValue(mockAdminUser);
       await Page();
       expect(redirect).not.toHaveBeenCalled();
     });
@@ -69,7 +80,7 @@ describe('Page', () => {
 
   describe('rendering', () => {
     beforeEach(() => {
-      getCurrentUser.mockResolvedValue(mockUser);
+      getCurrentUser.mockResolvedValue(mockAdminUser);
     });
 
     it('should render the page title', async () => {
@@ -77,16 +88,12 @@ describe('Page', () => {
       expect(screen.getByText('Desempenho do Time')).toBeInTheDocument();
     });
 
-    it('should render the page subtitle', async () => {
+    it('should render the auto-refresh component', async () => {
       render(await Page());
-      expect(
-        screen.getByText(
-          'Acompanhe rankings, assiduidade e evolução no atendimento'
-        )
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('auto-refresh')).toBeInTheDocument();
     });
 
-    it('should render the KPI cards', async () => {
+    it('should render KPI cards', async () => {
       render(await Page());
       expect(screen.getByTestId('kpi-cards')).toBeInTheDocument();
     });

--- a/src/app/tv/dashboards/page.tsx
+++ b/src/app/tv/dashboards/page.tsx
@@ -9,13 +9,14 @@ import {
   KpiCardsSkeleton,
   RankingSkeleton,
 } from '@/app/components/dashboards/skeletons';
+import AutoRefresh from '@/app/components/tv/auto-refresh';
 import { getCurrentUser } from '@/app/libs/session';
 import { adminRoles } from '@/app/utils/roles';
 import { TrophyIcon } from '@heroicons/react/24/outline';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 
-export default async function Page() {
+export default async function TvDashboardPage() {
   const user = await getCurrentUser();
 
   if (!user) {
@@ -27,17 +28,15 @@ export default async function Page() {
   }
 
   return (
-    <main className="flex flex-col gap-6">
-      <div>
+    <main className="flex min-h-screen flex-col gap-4 p-4 lg:gap-6 lg:p-6 2xl:p-8">
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <TrophyIcon className="h-6 w-6 text-amber-500" />
-          <h1 className="text-xl font-bold text-gray-900 md:text-2xl">
+          <TrophyIcon className="h-5 w-5 text-amber-500 lg:h-6 lg:w-6" />
+          <h1 className="text-lg font-bold text-gray-900 lg:text-xl 2xl:text-2xl">
             Desempenho do Time
           </h1>
         </div>
-        <p className="mt-0.5 text-sm text-gray-500">
-          Acompanhe rankings, assiduidade e evolução no atendimento
-        </p>
+        <AutoRefresh />
       </div>
 
       <Suspense
@@ -50,19 +49,18 @@ export default async function Page() {
         <KpiCards />
       </Suspense>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="grid flex-1 grid-cols-1 gap-4 lg:grid-cols-2 2xl:grid-cols-3">
         <Suspense fallback={<RankingSkeleton />}>
           <Ranking />
         </Suspense>
 
-        <div className="flex flex-col gap-4">
-          <Suspense fallback={<AttendanceBonusSkeleton />}>
-            <AttendanceBonusServer />
-          </Suspense>
-          <Suspense fallback={<ChartSkeleton />}>
-            <PerformanceChartServer />
-          </Suspense>
-        </div>
+        <Suspense fallback={<AttendanceBonusSkeleton />}>
+          <AttendanceBonusServer />
+        </Suspense>
+
+        <Suspense fallback={<ChartSkeleton />}>
+          <PerformanceChartServer />
+        </Suspense>
       </div>
     </main>
   );

--- a/src/app/tv/layout.tsx
+++ b/src/app/tv/layout.tsx
@@ -1,0 +1,3 @@
+export default function TvLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-gray-100">{children}</div>;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+const TV_UA_PATTERNS = [
+  /\bAFT\b/i, // Amazon Fire TV / Fire Stick
+  /\bFireTV\b/i, // Amazon Fire TV explicit
+  /\bwebOS\b/i, // LG Smart TV
+  /\bTizen\b/i, // Samsung Smart TV
+  /\bSMART-TV\b/i, // Generic Smart TV
+  /\bAppleTV\b/i, // Apple TV
+  /\bRoku\b/i, // Roku
+  /\bCrKey\b/i, // Chromecast with Google TV
+  /\bGoogleTV\b/i, // Google TV
+  /Android.*\bTV\b/i, // Android TV
+];
+
+function isTvDevice(userAgent: string): boolean {
+  return TV_UA_PATTERNS.some((pattern) => pattern.test(userAgent));
+}
+
 export function middleware(req: NextRequest) {
   const jwt = req.cookies.get('jwt');
-  const isLoginPage = req.nextUrl.pathname === '/login';
+  const { pathname } = req.nextUrl;
+  const isLoginPage = pathname === '/login';
+  const isHomePage = pathname === '/home';
+  const isTv = isTvDevice(req.headers.get('user-agent') ?? '');
 
   if (jwt && isLoginPage) {
-    return NextResponse.redirect(new URL('/home', req.url));
+    const destination = isTv ? '/tv/dashboards' : '/home';
+    return NextResponse.redirect(new URL(destination, req.url));
+  }
+
+  if (jwt && isHomePage && isTv) {
+    return NextResponse.redirect(new URL('/tv/dashboards', req.url));
   }
 
   if (!jwt && !isLoginPage) {
@@ -27,5 +52,6 @@ export const config = {
     '/partners/:path*',
     '/payments/:path*',
     '/users/:path*',
+    '/tv/:path*',
   ],
 };


### PR DESCRIPTION
## Summary

- **Refatoração do dashboard**: novo layout com 2 KPIs (Casos Finalizados + SLA no Prazo), Ranking com farol de atrasos e divisão Vistoria/Reparo, board de gamificação "Bônus Assiduidade" e gráfico TMA vs Volume
- **Conexão com dados reais (BFF)**: todos os componentes do dashboard agora consomem o backend via server services (`fetch_dashboard_kpis`, `fetch_ranking`, `fetch_performance_chart`, `fetch_operators`)
- **Rota `/tv/dashboards`**: layout fullscreen sem sidebar, grid responsivo 1-col → 2-col (lg) → 3-col (2xl) para 1080p/4K, auto-refresh configurável via `NEXT_PUBLIC_TV_REFRESH_MS` (padrão: 2 min)
- **Auto-redirect para TV**: middleware detecta dispositivos TV por User-Agent (Fire TV, LG WebOS, Samsung Tizen, Apple TV, Roku, Chromecast com Google TV, Android TV) e redireciona automaticamente para `/tv/dashboards`
- **Fix**: testes do `ControlPanelTable` corrigidos — fixtures atualizadas de `CaseFull` para `PanelCaseItem` para bater com o tipo real do componente

## Dependência de backend

Esta PR exige que o branch `feature/dashboard-refactor` do `crm-api-core` seja mergeado antes do deploy, pois os novos filtros `closed_at_start` / `closed_at_end` no endpoint `GET /cases` são usados por todos os três serviços de dashboard.

## Test plan

- [ ] Todos os 166 testes passando (`npm test`)
- [ ] Acessar `/dashboards` como admin — verificar KPIs, Ranking, AttendanceBonus e PerformanceChart com dados reais
- [ ] Acessar `/tv/dashboards` — verificar layout fullscreen 3 colunas e countdown de refresh no header
- [ ] Simular UA de Fire TV no browser (DevTools → Network conditions) e fazer login — verificar redirect automático para `/tv/dashboards`
- [ ] Acessar `/tv/dashboards` sem autenticação — verificar redirect para `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)